### PR TITLE
Add cloudbuild support

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,3 @@
+steps:
+- name: 'gcr.io/config-validator/make'
+  args: ['test']

--- a/cloudbuild/Dockerfile
+++ b/cloudbuild/Dockerfile
@@ -1,0 +1,11 @@
+# This Dockerfile builds the image used in Cloud Build CI to run 'make test'.
+# To push a new image, run 'gcloud builds submit --project=config-validator --tag gcr.io/config-validator/make .'
+# from this directory.
+
+FROM debian
+
+RUN apt-get update && apt-get install -y build-essential
+RUN curl -L -o /usr/local/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.10.7/opa_linux_amd64 && \
+  chmod 755 /usr/local/bin/opa
+
+ENTRYPOINT ["make"]


### PR DESCRIPTION
It just runs "make test" for now.
See https://github.com/t12g/policy-library/pull/2/checks?check_run_id=99625649 for test run output.