### PR TITLE
Add make target for building and pushing Cloud Build Docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,5 +37,9 @@ format: ## Format Rego rules
 .PHONY: build
 build: format build_templates ## Format and build
 
+.PHONY: push_make_image
+push_make_image: ## Construct and push Docker image for Cloud Build CI to gcr.io/config-validator/make
+	@cd cloudbuild && gcloud builds submit --project=config-validator --tag gcr.io/config-validator/make .
+
 help: ## Prints help for targets with comments
 	@grep -E '^[a-zA-Z._-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "make \033[36m%- 30s\033[0m %s\n", $$1, $$2}'

--- a/cloudbuild/Dockerfile
+++ b/cloudbuild/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM debian
 
-RUN apt-get update && apt-get install -y build-essential
+RUN apt-get update && apt-get install -y build-essential curl
 RUN curl -L -o /usr/local/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.10.7/opa_linux_amd64 && \
   chmod 755 /usr/local/bin/opa
 


### PR DESCRIPTION
Also add curl installation in the Dockerfile. It was accidentally taken out in the previous PR.