### PR TITLE
Add version information as constraint template name suffix

### DIFF
--- a/policies/templates/gcp_always_violates.yaml
+++ b/policies/templates/gcp_always_violates.yaml
@@ -20,7 +20,7 @@ spec:
   crd:
     spec:
       names:
-        kind: GCPAlwaysViolatesConstraintv1
+        kind: GCPAlwaysViolatesConstraintV1
         plural: GCPAlwaysViolatesConstraints
         singular: GCPAlwaysViolatesConstraint
       validation:
@@ -46,7 +46,7 @@ spec:
            # limitations under the License.
            #
            
-           package templates.gcp.GCPAlwaysViolatesConstraintv1
+           package templates.gcp.GCPAlwaysViolatesConstraintV1
            
            import data.validator.gcp.lib as lib
            

--- a/policies/templates/gcp_always_violates.yaml
+++ b/policies/templates/gcp_always_violates.yaml
@@ -20,8 +20,7 @@ spec:
   crd:
     spec:
       names:
-        kind: GCPAlwaysViolatesConstraint
-        listKind: GCPAlwaysViolatesConstraintList
+        kind: GCPAlwaysViolatesConstraintv1
         plural: GCPAlwaysViolatesConstraints
         singular: GCPAlwaysViolatesConstraint
       validation:
@@ -47,7 +46,7 @@ spec:
            # limitations under the License.
            #
            
-           package templates.gcp.GCPAlwaysViolatesConstraint
+           package templates.gcp.GCPAlwaysViolatesConstraintv1
            
            import data.validator.gcp.lib as lib
            

--- a/validator/always_violates.rego
+++ b/validator/always_violates.rego
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-package templates.gcp.GCPAlwaysViolatesConstraint
+package templates.gcp.GCPAlwaysViolatesConstraintv1
 
 import data.validator.gcp.lib as lib
 

--- a/validator/always_violates.rego
+++ b/validator/always_violates.rego
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-package templates.gcp.GCPAlwaysViolatesConstraintv1
+package templates.gcp.GCPAlwaysViolatesConstraintV1
 
 import data.validator.gcp.lib as lib
 

--- a/validator/always_violates_test.rego
+++ b/validator/always_violates_test.rego
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-package templates.gcp.GCPAlwaysViolatesConstraint
+package templates.gcp.GCPAlwaysViolatesConstraintv1
 
 # Confirm total violations count
 always_violates_all_violations[output] {

--- a/validator/always_violates_test.rego
+++ b/validator/always_violates_test.rego
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-package templates.gcp.GCPAlwaysViolatesConstraintv1
+package templates.gcp.GCPAlwaysViolatesConstraintV1
 
 # Confirm total violations count
 always_violates_all_violations[output] {

--- a/validator/test/fixtures/constraints/always_violates_all/data.yaml
+++ b/validator/test/fixtures/constraints/always_violates_all/data.yaml
@@ -13,11 +13,10 @@
 # limitations under the License.
 #
 apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPAlwaysViolatesConstraint
+kind: GCPAlwaysViolatesConstraintv1
 metadata:
   name: always_violates_all
 spec:
-  constraintVersion: 0.1.0
   severity: high
   match:
     gcp:

--- a/validator/test/fixtures/constraints/always_violates_all/data.yaml
+++ b/validator/test/fixtures/constraints/always_violates_all/data.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPAlwaysViolatesConstraintv1
+kind: GCPAlwaysViolatesConstraintV1
 metadata:
   name: always_violates_all
 spec:


### PR DESCRIPTION
As discussed, we'll start with v1. If this looks good, I'll apply the change to other constraint templates in a follow-up PR.

Also remove the following fields:
* "listKind", since it defaults to <kind>List
* "constraintVersion", since version it's now part of constraint template name
