### PR TITLE
Append "V1" version suffix to constraint template name

### DIFF
--- a/policies/templates/gcp_always_violates.yaml
+++ b/policies/templates/gcp_always_violates.yaml
@@ -21,8 +21,7 @@ spec:
     spec:
       names:
         kind: GCPAlwaysViolatesConstraintV1
-        plural: GCPAlwaysViolatesConstraints
-        singular: GCPAlwaysViolatesConstraint
+        plural: gcpalwaysviolatesconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_external_ip_access.yaml
+++ b/policies/templates/gcp_external_ip_access.yaml
@@ -23,8 +23,7 @@ spec:
   crd:
     spec:
       names:
-        kind: GCPExternalIpAccessConstraint
-        listKind: GCPExternalIpAccessConstraintList
+        kind: GCPExternalIpAccessConstraintV1
         plural: GCPExternalIpAccessConstraints
         singular: GCPExternalIpAccessConstraint
       validation:
@@ -73,7 +72,7 @@ spec:
 
             
 
-            package templates.gcp.GCPExternalIpAccessConstraint
+            package templates.gcp.GCPExternalIpAccessConstraintV1
 
             
 

--- a/policies/templates/gcp_external_ip_access.yaml
+++ b/policies/templates/gcp_external_ip_access.yaml
@@ -24,8 +24,7 @@ spec:
     spec:
       names:
         kind: GCPExternalIpAccessConstraintV1
-        plural: GCPExternalIpAccessConstraints
-        singular: GCPExternalIpAccessConstraint
+        plural: gcpexternalipaccessconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_iam_allowed_policy_member_domains.yaml
+++ b/policies/templates/gcp_iam_allowed_policy_member_domains.yaml
@@ -21,8 +21,7 @@ spec:
     spec:
       names:
         kind: GCPIAMAllowedPolicyMemberDomainsConstraintV1
-        plural: GCPIAMAllowedPolicyMemberDomainsConstraints
-        singular: GCPIAMAllowedPolicyMemberDomainsConstraint
+        plural: gcpiamallowedpolicymemberdomainsconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_iam_allowed_policy_member_domains.yaml
+++ b/policies/templates/gcp_iam_allowed_policy_member_domains.yaml
@@ -20,8 +20,7 @@ spec:
   crd:
     spec:
       names:
-        kind: GCPIAMAllowedPolicyMemberDomainsConstraint
-        listKind: GCPIAMAllowedPolicyMemberDomainsConstraintList
+        kind: GCPIAMAllowedPolicyMemberDomainsConstraintV1
         plural: GCPIAMAllowedPolicyMemberDomainsConstraints
         singular: GCPIAMAllowedPolicyMemberDomainsConstraint
       validation:
@@ -68,7 +67,7 @@ spec:
            # limitations under the License.
            #
            
-           package templates.gcp.GCPIAMAllowedPolicyMemberDomainsConstraint
+           package templates.gcp.GCPIAMAllowedPolicyMemberDomainsConstraintV1
            
            import data.validator.gcp.lib as lib
            

--- a/policies/templates/gcp_network_routing.yaml
+++ b/policies/templates/gcp_network_routing.yaml
@@ -21,8 +21,7 @@ spec:
     spec:
       names:
         kind: GCPNetworkRoutingConstraintV1
-        plural: GCPNetworkRoutingConstraints
-        singular: GCPNetworkRoutingConstraint
+        plural: gcpnetworkroutingconstraintsv1
       validation:
         openAPIV3Schema:
           mode:

--- a/policies/templates/gcp_network_routing.yaml
+++ b/policies/templates/gcp_network_routing.yaml
@@ -20,8 +20,7 @@ spec:
   crd:
     spec:
       names:
-        kind: GCPNetworkRoutingConstraint
-        listKind: GCPNetworkRoutingConstraintList
+        kind: GCPNetworkRoutingConstraintV1
         plural: GCPNetworkRoutingConstraints
         singular: GCPNetworkRoutingConstraint
       validation:
@@ -49,7 +48,7 @@ spec:
             # limitations under the License.
             #
             
-            package templates.gcp.GCPNetworkRoutingConstraint
+            package templates.gcp.GCPNetworkRoutingConstraintV1
             
             import data.validator.gcp.lib as lib
             

--- a/policies/templates/gcp_storage_logging.yaml
+++ b/policies/templates/gcp_storage_logging.yaml
@@ -21,8 +21,7 @@ spec:
     spec:
       names:
         kind: GCPStorageLoggingConstraintV1
-        plural: GCPStorageLoggingConstraints
-        singular: GCPStorageLoggingConstraint
+        plural: gcpstorageloggingconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_storage_logging.yaml
+++ b/policies/templates/gcp_storage_logging.yaml
@@ -20,8 +20,7 @@ spec:
   crd:
     spec:
       names:
-        kind: GCPStorageLoggingConstraint
-        listKind: GCPStorageLoggingConstraintList
+        kind: GCPStorageLoggingConstraintV1
         plural: GCPStorageLoggingConstraints
         singular: GCPStorageLoggingConstraint
       validation:
@@ -47,7 +46,7 @@ spec:
             # limitations under the License.
             #
             
-            package templates.gcp.GCPStorageLoggingConstraint
+            package templates.gcp.GCPStorageLoggingConstraintV1
             
             import data.validator.gcp.lib as lib
             

--- a/samples/always_violates.yaml
+++ b/samples/always_violates.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPAlwaysViolatesConstraint
+kind: GCPAlwaysViolatesConstraintV1
 metadata:
   name: always_violates_all
 spec:

--- a/samples/iam_service_accounts_only.yaml
+++ b/samples/iam_service_accounts_only.yaml
@@ -1,7 +1,7 @@
 # This constraint checks that all IAM policy members are in the
 # "gserviceaccount.com" domain.
 apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPIAMAllowedPolicyMemberDomainsConstraint
+kind: GCPIAMAllowedPolicyMemberDomainsConstraintV1
 metadata:
   name: service_accounts_only
 spec:

--- a/validator/iam_allowed_policy_member_domains.rego
+++ b/validator/iam_allowed_policy_member_domains.rego
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-package templates.gcp.GCPIAMAllowedPolicyMemberDomainsConstraint
+package templates.gcp.GCPIAMAllowedPolicyMemberDomainsConstraintV1
 
 import data.validator.gcp.lib as lib
 

--- a/validator/iam_allowed_policy_member_domains_test.rego
+++ b/validator/iam_allowed_policy_member_domains_test.rego
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-package templates.gcp.GCPIAMAllowedPolicyMemberDomainsConstraint
+package templates.gcp.GCPIAMAllowedPolicyMemberDomainsConstraintV1
 
 import data.test.fixtures.assets.projects_iam as fixture_assets
 import data.test.fixtures.constraints as fixture_constraints

--- a/validator/network_routing.rego
+++ b/validator/network_routing.rego
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-package templates.gcp.GCPNetworkRoutingConstraint
+package templates.gcp.GCPNetworkRoutingConstraintV1
 
 import data.validator.gcp.lib as lib
 

--- a/validator/network_routing_test.rego
+++ b/validator/network_routing_test.rego
@@ -1,4 +1,4 @@
-package templates.gcp.GCPNetworkRoutingConstraint
+package templates.gcp.GCPNetworkRoutingConstraintV1
 
 all_violations[violation] {
 	resource := data.test.fixtures.assets.networks[_]

--- a/validator/storage_logging.rego
+++ b/validator/storage_logging.rego
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-package templates.gcp.GCPStorageLoggingConstraint
+package templates.gcp.GCPStorageLoggingConstraintV1
 
 import data.validator.gcp.lib as lib
 

--- a/validator/storage_logging_test.rego
+++ b/validator/storage_logging_test.rego
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-package templates.gcp.GCPStorageLoggingConstraint
+package templates.gcp.GCPStorageLoggingConstraintV1
 
 all_violations[violation] {
 	resource := data.test.fixtures.assets.storage_buckets[_]

--- a/validator/test/fixtures/constraints/forbid_external_ip_blacklist/data.yaml
+++ b/validator/test/fixtures/constraints/forbid_external_ip_blacklist/data.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPExternalIpAccessConstraint
+kind: GCPExternalIpAccessConstraintV1
 metadata:
   name: forbid_external_api_blacklist
 spec:

--- a/validator/test/fixtures/constraints/forbid_external_ip_blacklist_all/data.yaml
+++ b/validator/test/fixtures/constraints/forbid_external_ip_blacklist_all/data.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPExternalIpAccessConstraint
+kind: GCPExternalIpAccessConstraintV1
 metadata:
   name: forbid_external_ip_blacklist_all
 spec:

--- a/validator/test/fixtures/constraints/forbid_external_ip_default/data.yaml
+++ b/validator/test/fixtures/constraints/forbid_external_ip_default/data.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPExternalIpAccessConstraint
+kind: GCPExternalIpAccessConstraintV1
 metadata:
   name: forbid_external_ip_default
 spec:

--- a/validator/test/fixtures/constraints/forbid_external_ip_whitelist/data.yaml
+++ b/validator/test/fixtures/constraints/forbid_external_ip_whitelist/data.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPExternalIpAccessConstraint
+kind: GCPExternalIpAccessConstraintV1
 metadata:
   name: forbid_external_api_whitelist
 spec:

--- a/validator/test/fixtures/constraints/forbid_external_ip_whitelist_all/data.yaml
+++ b/validator/test/fixtures/constraints/forbid_external_ip_whitelist_all/data.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPExternalIpAccessConstraint
+kind: GCPExternalIpAccessConstraintV1
 metadata:
   name: forbid_external_ip_whitelist_all
 spec:

--- a/validator/test/fixtures/constraints/iam_allowed_policy_member_all_domains/data.yaml
+++ b/validator/test/fixtures/constraints/iam_allowed_policy_member_all_domains/data.yaml
@@ -1,5 +1,5 @@
 apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPIAMAllowedPolicyMemberDomainsConstraint
+kind: GCPIAMAllowedPolicyMemberDomainsConstraintV1
 metadata:
   name: allow_everything
 spec:

--- a/validator/test/fixtures/constraints/iam_allowed_policy_member_reject_project_reference/data.yaml
+++ b/validator/test/fixtures/constraints/iam_allowed_policy_member_reject_project_reference/data.yaml
@@ -1,5 +1,5 @@
 apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPIAMAllowedPolicyMemberDomainsConstraint
+kind: GCPIAMAllowedPolicyMemberDomainsConstraintV1
 metadata:
   name: reject_project_reference
 spec:

--- a/validator/test/fixtures/constraints/iam_allowed_policy_member_two_domains/data.yaml
+++ b/validator/test/fixtures/constraints/iam_allowed_policy_member_two_domains/data.yaml
@@ -1,5 +1,5 @@
 apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPIAMAllowedPolicyMemberDomainsConstraint
+kind: GCPIAMAllowedPolicyMemberDomainsConstraintV1
 metadata:
   name: allow_google_and_gserviceaccount_dot_com
 spec:

--- a/validator/test/fixtures/constraints/network_routing/data.yaml
+++ b/validator/test/fixtures/constraints/network_routing/data.yaml
@@ -1,5 +1,5 @@
 apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPNetworkRoutingConstraint
+kind: GCPNetworkRoutingConstraintV1
 metadata:
   name: require_global_routing
 spec:

--- a/validator/test/fixtures/constraints/require_storage_logging/data.yaml
+++ b/validator/test/fixtures/constraints/require_storage_logging/data.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPStorageLoggingConstraint
+kind: GCPStorageLoggingConstraintV1
 metadata:
   name: require_storage_logging
   annotations:

--- a/validator/vm_external_ip.rego
+++ b/validator/vm_external_ip.rego
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-package templates.gcp.GCPExternalIpAccessConstraint
+package templates.gcp.GCPExternalIpAccessConstraintV1
 
 import data.validator.gcp.lib as lib
 

--- a/validator/vm_external_ip_test.rego
+++ b/validator/vm_external_ip_test.rego
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-package templates.gcp.GCPExternalIpAccessConstraint
+package templates.gcp.GCPExternalIpAccessConstraintV1
 
 import data.test.fixtures.assets.compute_instances as fixture_instances
 import data.test.fixtures.constraints as fixture_constraints


### PR DESCRIPTION
Follow up to https://github.com/forseti-security/policy-library/pull/19

Also remove redundant listKind field in constraint templates.