### PR TITLE
Add constraint to restrict IAM bindings

### DIFF
--- a/policies/templates/gcp_iam_allowed_bindings.yaml
+++ b/policies/templates/gcp_iam_allowed_bindings.yaml
@@ -62,7 +62,6 @@ spec:
           
           import data.validator.gcp.lib as lib
           
-          # If a primary domain is whitelisted, all of its sub domains are whitelisted as well.
           deny[{
           	"msg": message,
           	"details": metadata,

--- a/policies/templates/gcp_iam_allowed_bindings.yaml
+++ b/policies/templates/gcp_iam_allowed_bindings.yaml
@@ -21,17 +21,21 @@ spec:
     spec:
       names:
         kind: GCPIAMAllowedBindingsConstraintV1
-        plural: GCPIAMAllowedBindingsConstraintsV1
-        singular: GCPIAMAllowedBindingsConstraintV1
+        plural: gcpiamallowedbindingsconstraintsv1
       validation:
         openAPIV3Schema:
           properties:
             mode:
+              description: "Enforcement mode, defaults to whitelist"
               type: string
               enum: [blacklist, whitelist]
             role:
+              description: "Role to restrict bindings for,
+                ex. roles/owner; Wildcards (*) supported"
               type: string
             members:
+              description: "Members to either allow or deny for the given role,
+                depending on mode; Wildcards (*) supported"
               type: array
               items: string
   targets:

--- a/policies/templates/gcp_iam_allowed_bindings.yaml
+++ b/policies/templates/gcp_iam_allowed_bindings.yaml
@@ -1,0 +1,102 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: templates.gatekeeper.sh/v1alpha1
+kind: ConstraintTemplate
+metadata:
+  name: gcp-iam-allowed-bindings
+spec:
+  crd:
+    spec:
+      names:
+        kind: GCPIAMAllowedBindingsConstraintV1
+        plural: GCPIAMAllowedBindingsConstraintsV1
+        singular: GCPIAMAllowedBindingsConstraintV1
+      validation:
+        openAPIV3Schema:
+          properties:
+            mode:
+              type: string
+              enum: [blacklist, whitelist]
+            role:
+              type: string
+            members:
+              type: array
+              items: string
+  targets:
+   validation.gcp.forsetisecurity.org:
+      rego: |
+          #INLINE("validator/iam_allowed_bindings.rego")
+          #
+          # Copyright 2019 Google LLC
+          #
+          # Licensed under the Apache License, Version 2.0 (the "License");
+          # you may not use this file except in compliance with the License.
+          # You may obtain a copy of the License at
+          #
+          #      http://www.apache.org/licenses/LICENSE-2.0
+          #
+          # Unless required by applicable law or agreed to in writing, software
+          # distributed under the License is distributed on an "AS IS" BASIS,
+          # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+          # See the License for the specific language governing permissions and
+          # limitations under the License.
+          #
+          
+          package templates.gcp.GCPIAMAllowedBindingsConstraintV1
+          
+          import data.validator.gcp.lib as lib
+          
+          # If a primary domain is whitelisted, all of its sub domains are whitelisted as well.
+          deny[{
+          	"msg": message,
+          	"details": metadata,
+          }] {
+          	constraint := input.constraint
+          	lib.get_constraint_params(constraint, params)
+          	asset := input.asset
+          
+          	binding := asset.iam_policy.bindings[_]
+          	member := binding.members[_]
+          	role := binding.role
+          
+          	glob.match(params.role, [], role)
+          
+          	mode := lib.get_default(params, "mode", "whitelist")
+          
+          	matches_found = [m | m = params.members[_]; glob.match(m, [], member)]
+          	target_match_count(mode, desired_count)
+          	count(matches_found) != desired_count
+          
+          	message := sprintf("IAM policy for %v grants %v to %v", [asset.name, role, member])
+          
+          	metadata := {
+          		"member": member,
+          		"role": role,
+          	}
+          }
+          
+          ###########################
+          # Rule Utilities
+          ###########################
+          
+          # Determine the overlap between matches under test and constraint
+          target_match_count(mode) = 0 {
+          	mode == "blacklist"
+          }
+          
+          target_match_count(mode) = 1 {
+          	mode == "whitelist"
+          }
+          #ENDINLINE

--- a/samples/iam_blacklist_public.yaml
+++ b/samples/iam_blacklist_public.yaml
@@ -1,0 +1,17 @@
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPIAMAllowedBindingsConstraintV1
+metadata:
+  name: blacklist_all_users
+  annotations:
+    description: Prevent public users from having access to resources via IAM
+spec:
+  severity: high
+  match:
+    target: ["organization/*"]
+    exclude: [] # optional, default is no exclusions
+  parameters:
+    mode: blacklist
+    role: "roles/*"
+    members:
+    - "allUsers"
+    - "allAuthenticatedUsers"

--- a/samples/iam_blacklist_role.yaml
+++ b/samples/iam_blacklist_role.yaml
@@ -1,7 +1,7 @@
 apiVersion: constraints.gatekeeper.sh/v1alpha1
 kind: GCPIAMAllowedBindingsConstraintV1
 metadata:
-  name: blacklist_cloudasset_role
+  name: blacklist_serviceaccount_user
   annotations:
     description: Ban any users from being granted Service Account User access
     benchmark: CIS11_1.05

--- a/samples/iam_blacklist_role.yaml
+++ b/samples/iam_blacklist_role.yaml
@@ -3,7 +3,8 @@ kind: GCPIAMAllowedBindingsConstraintV1
 metadata:
   name: blacklist_cloudasset_role
   annotations:
-    description: Ban any users from being granted a particular role
+    description: Ban any users from being granted Service Account User access
+    benchmark: CIS11_1.05
 spec:
   severity: high
   match:
@@ -11,6 +12,6 @@ spec:
     exclude: [] # optional, default is no exclusions
   parameters:
     mode: blacklist
-    role: roles/cloudasset.*
+    role: roles/iam.serviceAccountUser
     members:
       - "*"

--- a/samples/iam_blacklist_role.yaml
+++ b/samples/iam_blacklist_role.yaml
@@ -1,0 +1,16 @@
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPIAMAllowedBindingsConstraintV1
+metadata:
+  name: blacklist_cloudasset_role
+  annotations:
+    description: Ban any users from being granted a particular role
+spec:
+  severity: high
+  match:
+    target: ["organization/*"]
+    exclude: [] # optional, default is no exclusions
+  parameters:
+    mode: blacklist
+    role: roles/cloudasset.*
+    members:
+      - "*"

--- a/samples/iam_restrict_role.yaml
+++ b/samples/iam_restrict_role.yaml
@@ -1,0 +1,17 @@
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPIAMAllowedBindingsConstraintV1
+metadata:
+  name: whitelist_owner_role
+  annotations:
+    description: All projects must have owner from my domain
+spec:
+  severity: high
+  match:
+    target: ["organization/*"]
+    exclude: [] # optional, default is no exclusions
+  parameters:
+    mode: whitelist
+    role: roles/owner
+    members:
+    - "user:*@google.com"
+    - "group:*@google.com"

--- a/validator/iam_allowed_bindings.rego
+++ b/validator/iam_allowed_bindings.rego
@@ -1,0 +1,75 @@
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package templates.gcp.GCPIAMAllowedBindingsConstraintV1
+
+import data.validator.gcp.lib as lib
+
+# If a primary domain is whitelisted, all of its sub domains are whitelisted as well.
+deny[{
+	"msg": message,
+	"details": metadata,
+}] {
+	constraint := input.constraint
+	lib.get_constraint_params(constraint, params)
+	asset := input.asset
+
+	binding := asset.iam_policy.bindings[_]
+	member := binding.members[_]
+	role := binding.role
+
+	glob.match(params.role, [], role)
+
+	mode := lib.get_default(params, "mode", "whitelist")
+
+	matches_found = [m | m = params.members[_]; glob.match(m, [], member)]
+	target_match_count(mode, desired_count)
+	count(matches_found) != desired_count
+
+	# Check if a match is found
+	# not binding_matches(member, role, params.bindings)
+
+	# member_type_whitelist := lib.get_default(params, "member_type_whitelist", ["projectOwner", "projectEditor", "projectViewer"])
+
+	# members_to_check := [m | m = unique_members[_]; not starts_with_whitelisted_type(member_type_whitelist, m)]
+	# member := members_to_check[_]
+	# matched_domains := [m | m = member; re_match(sprintf("[:@.]%v$", [params.domains[_]]), member)]
+	# count(matched_domains) == 0
+
+	message := sprintf("IAM policy for %v grants %v to %v", [asset.name, role, member])
+
+	metadata := {
+		"member": member,
+		# "binding": binding,
+		# "constraint": desired_count,
+		# "match": matches_found,
+		"member": member,
+		"role": role
+	}
+}
+
+###########################
+# Rule Utilities
+###########################
+
+# Determine the overlap between matches under test and constraint
+target_match_count(mode) = 0 {
+	mode == "blacklist"
+}
+
+target_match_count(mode) = 1 {
+	mode == "whitelist"
+}

--- a/validator/iam_allowed_bindings.rego
+++ b/validator/iam_allowed_bindings.rego
@@ -39,25 +39,11 @@ deny[{
 	target_match_count(mode, desired_count)
 	count(matches_found) != desired_count
 
-	# Check if a match is found
-	# not binding_matches(member, role, params.bindings)
-
-	# member_type_whitelist := lib.get_default(params, "member_type_whitelist", ["projectOwner", "projectEditor", "projectViewer"])
-
-	# members_to_check := [m | m = unique_members[_]; not starts_with_whitelisted_type(member_type_whitelist, m)]
-	# member := members_to_check[_]
-	# matched_domains := [m | m = member; re_match(sprintf("[:@.]%v$", [params.domains[_]]), member)]
-	# count(matched_domains) == 0
-
 	message := sprintf("IAM policy for %v grants %v to %v", [asset.name, role, member])
 
 	metadata := {
 		"member": member,
-		# "binding": binding,
-		# "constraint": desired_count,
-		# "match": matches_found,
-		"member": member,
-		"role": role
+		"role": role,
 	}
 }
 

--- a/validator/iam_allowed_bindings.rego
+++ b/validator/iam_allowed_bindings.rego
@@ -18,7 +18,6 @@ package templates.gcp.GCPIAMAllowedBindingsConstraintV1
 
 import data.validator.gcp.lib as lib
 
-# If a primary domain is whitelisted, all of its sub domains are whitelisted as well.
 deny[{
 	"msg": message,
 	"details": metadata,

--- a/validator/iam_allowed_bindings_test.rego
+++ b/validator/iam_allowed_bindings_test.rego
@@ -41,7 +41,7 @@ blacklist_role_violations[violation] {
 }
 
 test_blacklist_role_violations {
-	count(blacklist_role_violations) = 4
+	count(blacklist_role_violations) = 2
 	violation := blacklist_role_violations[_]
 }
 

--- a/validator/iam_allowed_bindings_test.rego
+++ b/validator/iam_allowed_bindings_test.rego
@@ -70,3 +70,17 @@ blacklist_public_violations[violation] {
 test_blacklist_public_violations {
 	count(blacklist_public_violations) = 2
 }
+
+
+# Try a constraint which shouldn't trigger any violations
+whitelist_role_no_violations[violation] {
+	constraints := [fixture_constraints.iam_allowed_bindings_whitelist_role_members]
+
+	found_violations := find_violations with data.test_constraints as constraints
+
+	violation := found_violations[_]
+}
+
+test_whitelist_role_no_violations {
+	count(whitelist_role_no_violations) = 0
+}

--- a/validator/iam_allowed_bindings_test.rego
+++ b/validator/iam_allowed_bindings_test.rego
@@ -1,0 +1,60 @@
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package templates.gcp.GCPIAMAllowedBindingsConstraintV1
+
+import data.test.fixtures.assets.projects_iam as fixture_assets
+import data.test.fixtures.constraints as fixture_constraints
+
+# Find all violations on our test cases
+find_violations[violation] {
+	asset := fixture_assets[_]
+	constraint := data.test_constraints[_]
+
+	issues := deny with input.asset as asset
+		 with input.constraint as constraint
+
+	total_issues := count(issues)
+
+	violation := issues[_]
+}
+
+blacklist_role_violations[violation] {
+	constraints := [fixture_constraints.iam_allowed_bindings_blacklist_role]
+
+	found_violations := find_violations with data.test_constraints as constraints
+
+	violation := found_violations[_]
+}
+
+test_blacklist_role_violations {
+	count(blacklist_role_violations) = 8
+	violation := blacklist_role_violations[_]
+}
+
+whitelist_role_domain_violations[violation] {
+	constraints := [fixture_constraints.iam_allowed_bindings_whitelist_role_domain]
+
+	found_violations := find_violations with data.test_constraints as constraints
+
+	violation := found_violations[_]
+}
+
+test_whitelist_role_domain_violations {
+	count(whitelist_role_domain_violations) = 1
+	violation := whitelist_role_domain_violations[_]
+	violation.details.role == "roles/owner"
+}

--- a/validator/iam_allowed_bindings_test.rego
+++ b/validator/iam_allowed_bindings_test.rego
@@ -16,7 +16,7 @@
 
 package templates.gcp.GCPIAMAllowedBindingsConstraintV1
 
-import data.test.fixtures.assets.projects_iam as fixture_assets
+import data.test.fixtures.assets.projects_iam_bindings as fixture_assets
 import data.test.fixtures.constraints as fixture_constraints
 
 # Find all violations on our test cases
@@ -41,7 +41,7 @@ blacklist_role_violations[violation] {
 }
 
 test_blacklist_role_violations {
-	count(blacklist_role_violations) = 8
+	count(blacklist_role_violations) = 4
 	violation := blacklist_role_violations[_]
 }
 
@@ -57,4 +57,17 @@ test_whitelist_role_domain_violations {
 	count(whitelist_role_domain_violations) = 1
 	violation := whitelist_role_domain_violations[_]
 	violation.details.role == "roles/owner"
+}
+
+blacklist_public_violations[violation] {
+	constraints := [fixture_constraints.iam_allowed_bindings_blacklist_public]
+
+	found_violations := find_violations with data.test_constraints as constraints
+
+	violation := found_violations[_]
+}
+
+test_blacklist_public_violations {
+	count(blacklist_public_violations) = 2
+	violation := whitelist_role_domain_violations[_]
 }

--- a/validator/iam_allowed_bindings_test.rego
+++ b/validator/iam_allowed_bindings_test.rego
@@ -42,7 +42,6 @@ blacklist_role_violations[violation] {
 
 test_blacklist_role_violations {
 	count(blacklist_role_violations) = 2
-	violation := blacklist_role_violations[_]
 }
 
 whitelist_role_domain_violations[violation] {
@@ -57,6 +56,7 @@ test_whitelist_role_domain_violations {
 	count(whitelist_role_domain_violations) = 1
 	violation := whitelist_role_domain_violations[_]
 	violation.details.role == "roles/owner"
+	violation.details.member == "user:evil@notgoogle.com"
 }
 
 blacklist_public_violations[violation] {
@@ -69,5 +69,4 @@ blacklist_public_violations[violation] {
 
 test_blacklist_public_violations {
 	count(blacklist_public_violations) = 2
-	violation := whitelist_role_domain_violations[_]
 }

--- a/validator/iam_allowed_bindings_test.rego
+++ b/validator/iam_allowed_bindings_test.rego
@@ -71,7 +71,6 @@ test_blacklist_public_violations {
 	count(blacklist_public_violations) = 2
 }
 
-
 # Try a constraint which shouldn't trigger any violations
 whitelist_role_no_violations[violation] {
 	constraints := [fixture_constraints.iam_allowed_bindings_whitelist_role_members]

--- a/validator/test/fixtures/assets/projects_iam/data.json
+++ b/validator/test/fixtures/assets/projects_iam/data.json
@@ -76,6 +76,14 @@
                     ]
                 },
                 {
+                    "role": "roles/owner",
+                    "members": [
+                        "user:powerful@google.com",
+                        "group:admins@google.com",
+                        "user:evil@notgoogle.com"
+                    ]
+                },
+                {
                     "role": "roles/dataflow.serviceAgent",
                     "members": [
                         "serviceAccount:service-12345@dataflow-service-producer-prod.iam.gserviceaccount.com",

--- a/validator/test/fixtures/assets/projects_iam/data.json
+++ b/validator/test/fixtures/assets/projects_iam/data.json
@@ -76,14 +76,6 @@
                     ]
                 },
                 {
-                    "role": "roles/owner",
-                    "members": [
-                        "user:powerful@google.com",
-                        "group:admins@google.com",
-                        "user:evil@notgoogle.com"
-                    ]
-                },
-                {
                     "role": "roles/dataflow.serviceAgent",
                     "members": [
                         "serviceAccount:service-12345@dataflow-service-producer-prod.iam.gserviceaccount.com",

--- a/validator/test/fixtures/assets/projects_iam_bindings/data.json
+++ b/validator/test/fixtures/assets/projects_iam_bindings/data.json
@@ -1,0 +1,42 @@
+[
+    {
+        "name": "//cloudresourcemanager.googleapis.com/projects/12345",
+        "asset_type": "cloudresourcemanager.googleapis.com/Project",
+        "iam_policy": {
+            "version": 1,
+            "etag": "CdWC1qPLfdw=",
+            "bindings": [
+                {
+                    "role": "roles/cloudasset.serviceAgent",
+                    "members": [
+                        "user:bad@notgoogle.com",
+                        "serviceAccount:service-12345@gcp-sa-cloudasset.iam.gserviceaccount.com"
+                    ]
+                },
+                {
+                    "role": "roles/cloudasset.viewer",
+                    "members": [
+                        "user:bad@notgoogle.com",
+                        "serviceAccount:service-12345@notiam.gserviceaccount.com"
+                    ]
+                },
+                {
+                    "role": "roles/owner",
+                    "members": [
+                        "user:powerful@google.com",
+                        "group:admins@google.com",
+                        "user:evil@notgoogle.com"
+                    ]
+                },
+                {
+                    "role": "roles/viewer",
+                    "members": [
+                        "allUsers",
+                        "allAuthenticatedUsers",
+                        "user:okay@google.com"
+                    ]
+                }
+            ]
+        }
+    }
+]

--- a/validator/test/fixtures/assets/projects_iam_bindings/data.json
+++ b/validator/test/fixtures/assets/projects_iam_bindings/data.json
@@ -7,14 +7,7 @@
             "etag": "CdWC1qPLfdw=",
             "bindings": [
                 {
-                    "role": "roles/cloudasset.serviceAgent",
-                    "members": [
-                        "user:bad@notgoogle.com",
-                        "serviceAccount:service-12345@gcp-sa-cloudasset.iam.gserviceaccount.com"
-                    ]
-                },
-                {
-                    "role": "roles/cloudasset.viewer",
+                    "role": "roles/iam.serviceAccountUser",
                     "members": [
                         "user:bad@notgoogle.com",
                         "serviceAccount:service-12345@notiam.gserviceaccount.com"

--- a/validator/test/fixtures/constraints/iam_allowed_bindings_blacklist_public/data.yaml
+++ b/validator/test/fixtures/constraints/iam_allowed_bindings_blacklist_public/data.yaml
@@ -1,17 +1,1 @@
-apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPIAMAllowedBindingsConstraintV1
-metadata:
-  name: blacklist_all_users
-  annotations:
-    description: Example of preventing adding allUsers to IAM policies
-spec:
-  severity: high
-  match:
-    target: ["organization/*"]
-    exclude: [] # optional, default is no exclusions
-  parameters:
-    mode: blacklist
-    role: "roles/*"
-    members:
-    - "allUsers"
-    - "allAuthenticatedUsers"
+../../../../../samples/iam_blacklist_public.yaml

--- a/validator/test/fixtures/constraints/iam_allowed_bindings_blacklist_public/data.yaml
+++ b/validator/test/fixtures/constraints/iam_allowed_bindings_blacklist_public/data.yaml
@@ -1,0 +1,17 @@
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPIAMAllowedBindingsConstraintV1
+metadata:
+  name: blacklist_all_users
+  annotations:
+    description: Example of preventing adding allUsers to IAM policies
+spec:
+  severity: high
+  match:
+    target: ["organization/*"]
+    exclude: [] # optional, default is no exclusions
+  parameters:
+    mode: blacklist
+    role: "roles/*"
+    members:
+    - "allUsers"
+    - "allAuthenticatedUsers"

--- a/validator/test/fixtures/constraints/iam_allowed_bindings_blacklist_role/data.yaml
+++ b/validator/test/fixtures/constraints/iam_allowed_bindings_blacklist_role/data.yaml
@@ -1,16 +1,1 @@
-apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPIAMAllowedBindingsConstraintV1
-metadata:
-  name: blacklist_cloudasset_role
-  annotations:
-    description: Example of blacklisting granting any roles for a product
-spec:
-  severity: high
-  match:
-    target: ["organization/*"]
-    exclude: [] # optional, default is no exclusions
-  parameters:
-    mode: blacklist
-    role: roles/cloudasset.*
-    members:
-      - "*"
+../../../../../samples/iam_blacklist_role.yaml

--- a/validator/test/fixtures/constraints/iam_allowed_bindings_blacklist_role/data.yaml
+++ b/validator/test/fixtures/constraints/iam_allowed_bindings_blacklist_role/data.yaml
@@ -1,0 +1,16 @@
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPIAMAllowedBindingsConstraintV1
+metadata:
+  name: blacklist_cloudasset_role
+  annotations:
+    description: Example of blacklisting granting any roles for a product
+spec:
+  severity: high
+  match:
+    target: ["organization/*"]
+    exclude: [] # optional, default is no exclusions
+  parameters:
+    mode: blacklist
+    role: roles/cloudasset.*
+    members:
+      - "*"

--- a/validator/test/fixtures/constraints/iam_allowed_bindings_whitelist_role_domain/data.yaml
+++ b/validator/test/fixtures/constraints/iam_allowed_bindings_whitelist_role_domain/data.yaml
@@ -1,17 +1,1 @@
-apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPIAMAllowedBindingsConstraintV1
-metadata:
-  name: whitelist_owner_role
-  annotations:
-    description: Example of restricting a role to only users from your domain
-spec:
-  severity: high
-  match:
-    target: ["organization/*"]
-    exclude: [] # optional, default is no exclusions
-  parameters:
-    mode: whitelist
-    role: roles/owner
-    members:
-    - "user:*@google.com"
-    - "group:*@google.com"
+../../../../../samples/iam_restrict_role.yaml

--- a/validator/test/fixtures/constraints/iam_allowed_bindings_whitelist_role_domain/data.yaml
+++ b/validator/test/fixtures/constraints/iam_allowed_bindings_whitelist_role_domain/data.yaml
@@ -1,0 +1,17 @@
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPIAMAllowedBindingsConstraintV1
+metadata:
+  name: whitelist_owner_role
+  annotations:
+    description: Example of restricting a role to only users from your domain
+spec:
+  severity: high
+  match:
+    target: ["organization/*"]
+    exclude: [] # optional, default is no exclusions
+  parameters:
+    mode: whitelist
+    role: roles/owner
+    members:
+    - "user:*@google.com"
+    - "group:*@google.com"

--- a/validator/test/fixtures/constraints/iam_allowed_bindings_whitelist_role_members/data.yaml
+++ b/validator/test/fixtures/constraints/iam_allowed_bindings_whitelist_role_members/data.yaml
@@ -1,0 +1,18 @@
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPIAMAllowedBindingsConstraintV1
+metadata:
+  name: whitelist_owner_role_members
+  annotations:
+    description: Whitelisted all known members (no violations)
+spec:
+  severity: high
+  match:
+    target: ["organization/*"]
+    exclude: [] # optional, default is no exclusions
+  parameters:
+    mode: whitelist
+    role: roles/owner
+    members:
+    - "user:*@google.com"
+    - "group:*@google.com"
+    - "user:evil@notgoogle.com"


### PR DESCRIPTION
This constraint provides feature parity with the [existing Forseti IAM rules](https://github.com/forseti-security/forseti-security/blob/master/rules/iam_rules.yaml).

Fixes #21.