### PR TITLE
Split template authoring section into its own page

### DIFF
--- a/docs/constraint_template_authoring.md
+++ b/docs/constraint_template_authoring.md
@@ -3,7 +3,7 @@
 This document is for advanced users who wish to create custom constraint
 templates.
 
-*Table of Contents*
+**Table of Contents**
 
 * [Template Authoring Convention](#template-authoring-convention)
   * [Naming](#naming)

--- a/docs/constraint_template_authoring.md
+++ b/docs/constraint_template_authoring.md
@@ -3,7 +3,7 @@
 This document is for advanced users who wish to create custom constraint
 templates.
 
-Table of Contents
+*Table of Contents*
 
 * [Template Authoring Convention](#template-authoring-convention)
   * [Naming](#naming)

--- a/docs/constraint_template_authoring.md
+++ b/docs/constraint_template_authoring.md
@@ -3,9 +3,23 @@
 This document is for advanced users who wish to create custom constraint
 templates.
 
-#### Template Authoring Convention
+Table of Contents
+=================
 
-##### Naming
+  * [Template Authoring Convention](#template-authoring-convention)
+            * [Naming](#naming)
+            * [Commentary](#commentary)
+         * [Validate your constraint goals and target resources](#validate-your-constraint-goals-and-target-resources)
+         * [Gather sample resource data](#gather-sample-resource-data)
+         * [Write Rego rule for constraint template](#write-rego-rule-for-constraint-template)
+         * [Write constraint and resource fixtures for your constraint template](#write-constraint-and-resource-fixtures-for-your-constraint-template)
+         * [Write Rego tests for your rule](#write-rego-tests-for-your-rule)
+         * [Create constraint template YAML definition](#create-constraint-template-yaml-definition)
+         * [Contact Info](#contact-info)
+
+### Template Authoring Convention
+
+#### Naming
 
 The template name appears in three places in a template YAML file:
 
@@ -33,14 +47,14 @@ for reasons behind this convention.
 The configuration YAML file name should take after the metadata name and replace
 "-" with "_" (example: "gcp_storage_logging_v1.yaml").
 
-##### Commentary
+#### Commentary
 
 Every configuration YAML file should have a summary at the top to describe the
 constraint. In the parameters section, every parameter should include a
 [description](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#properties)
 field to explain what the parameter does.
 
-#### Validate your constraint goals and target resources
+### Validate your constraint goals and target resources
 
 Before beginning to develop your constraint template, you should write a
 concrete definition of your goals in plain language. In writing this definition,
@@ -53,7 +67,7 @@ For example:
 The External IP Access Constraint will scan GCP VM instances and validate that the Access Config of their network interface does not include an external IP address.
 ```
 
-#### Gather sample resource data
+### Gather sample resource data
 
 Before proceeding to develop your template, you should verify that Cloud Asset
 Inventory
@@ -105,7 +119,7 @@ assigned to the VM.
 ]
 ```
 
-#### Write Rego rule for constraint template
+### Write Rego rule for constraint template
 
 In order to develop a constraint template, you must develop a Rego rule to back
 it. Before you begin, read about
@@ -178,7 +192,7 @@ target_instance_match_count(mode) = 1 {
 }
 ```
 
-#### Write constraint and resource fixtures for your constraint template
+### Write constraint and resource fixtures for your constraint template
 
 To test your rule, create fixtures of the expected resources and constraints
 leveraging your rule. To implement your test cases, gather resource fixtures
@@ -209,7 +223,7 @@ The rule above says that the external IP constraint applies to all
 organizations, but the GCE instance `vm-external-ip` under `test-project` in
 `us-east1-b` is exempt.
 
-#### Write Rego tests for your rule
+### Write Rego tests for your rule
 
 As you develop your constraint template, implement test cases that ensure your
 logic doesn't break over time. Open Policy Agent allows you to
@@ -260,7 +274,7 @@ test_external_whitelist_ip_violates_one {
 
 ```
 
-#### Create constraint template YAML definition
+### Create constraint template YAML definition
 
 Once you have a working Rego rule, you are ready to package it into a constraint
 template. You can do this by writing a YAML file which defines the expected
@@ -304,6 +318,6 @@ The Rego rule is supposed to be inlined in the YAML file. To do that, run `make
 build`. That will format the rego rules and inline them in the YAML files under
 the `#INLINE` directive.
 
-## Contact Info
+### Contact Info
 
 Questions or comments? Please contact validator-support@google.com.

--- a/docs/constraint_template_authoring.md
+++ b/docs/constraint_template_authoring.md
@@ -4,18 +4,17 @@ This document is for advanced users who wish to create custom constraint
 templates.
 
 Table of Contents
-=================
 
-  * [Template Authoring Convention](#template-authoring-convention)
-            * [Naming](#naming)
-            * [Commentary](#commentary)
-         * [Validate your constraint goals and target resources](#validate-your-constraint-goals-and-target-resources)
-         * [Gather sample resource data](#gather-sample-resource-data)
-         * [Write Rego rule for constraint template](#write-rego-rule-for-constraint-template)
-         * [Write constraint and resource fixtures for your constraint template](#write-constraint-and-resource-fixtures-for-your-constraint-template)
-         * [Write Rego tests for your rule](#write-rego-tests-for-your-rule)
-         * [Create constraint template YAML definition](#create-constraint-template-yaml-definition)
-         * [Contact Info](#contact-info)
+* [Template Authoring Convention](#template-authoring-convention)
+  * [Naming](#naming)
+  * [Commentary](#commentary)
+* [Validate your constraint goals and target resources](#validate-your-constraint-goals-and-target-resources)
+* [Gather sample resource data](#gather-sample-resource-data)
+* [Write Rego rule for constraint template](#write-rego-rule-for-constraint-template)
+* [Write constraint and resource fixtures for your constraint template](#write-constraint-and-resource-fixtures-for-your-constraint-template)
+* [Write Rego tests for your rule](#write-rego-tests-for-your-rule)
+* [Create constraint template YAML definition](#create-constraint-template-yaml-definition)
+* [Contact Info](#contact-info)
 
 ### Template Authoring Convention
 

--- a/docs/constraint_template_authoring.md
+++ b/docs/constraint_template_authoring.md
@@ -1,0 +1,309 @@
+## How to write your own custom constraint templates
+
+This document is for advanced users who wish to create custom constraint
+templates.
+
+#### Template Authoring Convention
+
+##### Naming
+
+The template name appears in three places in a template YAML file:
+
+*   metadata name: All lower case with "-" as the separator. It has the format
+    of "gcp-{resource}-{feature}-{version}" (example: "gcp-storage-logging-v1").
+*   CRD kind (under "spec" > "crd" > "spec" > "names" > "kind"): Camel case. It
+    has the format of "GCP{resource}{feature}Constraint{version}" (example:
+    "GCPStorageLoggingConstraintV1").
+*   CRD plural name (under "spec" > "crd" > "spec" > "names" > "plural"): Same
+    as CRD kind but in all lower case with the word "constraints" replacing
+    "constraint" (example: "gcpstorageloggingconstraintsv1")
+
+Wherever possible, follow [gcloud](https://cloud.google.com/sdk/gcloud/) group
+names for resource naming. For example, use "compute" instead of "gce", "sql"
+instead of "cloud-sql", and "container-cluster" instead of "gke".
+
+If a template applies to more than one type of resource, omit the resource part
+and only include the feature (example: "GCPExernalIPAccessV1").
+
+The version number does not follow semver form - it is just a single number.
+This effectively makes every version of a template an unique template. See
+[Constraint Framework: Versioning](https://docs.google.com/document/d/1vB_2wm60WCVLXoegMrupqwqKAuW6gbwEIxg3vBQj6cs/edit#)
+for reasons behind this convention.
+
+The configuration YAML file name should take after the metadata name and replace
+"-" with "_" (example: "gcp_storage_logging_v1.yaml").
+
+##### Commentary
+
+Every configuration YAML file should have a summary at the top to describe the
+constraint. In the parameters section, every parameter should include a
+[description](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#properties)
+field to explain what the parameter does.
+
+#### Validate your constraint goals and target resources
+
+Before beginning to develop your constraint template, you should write a
+concrete definition of your goals in plain language. In writing this definition,
+clearly define what resources you're looking to scan or analyze, and what
+properties of those resources you plan to constrain.
+
+For example:
+
+```
+The External IP Access Constraint will scan GCP VM instances and validate that the Access Config of their network interface does not include an external IP address.
+```
+
+#### Gather sample resource data
+
+Before proceeding to develop your template, you should verify that Cloud Asset
+Inventory
+[supports](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview#supported_resource_types)
+the resources you want. Assuming it does, you should gather some sample data to
+use in developing and testing your rule by creating resources of the appropriate
+type and creating a CAI export of those resources (see
+[CAI quickstart](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/quickstart-cloud-asset-inventory)).
+If the desired resource is not supported, please open a GitHub issue and/or
+email validator-support@google.com.
+
+For example, you might gather the following JSON export for external IP address
+constraint (for brevity, most fields are omitted). In the same data below, the
+presence of the `externalIp` field indicates that an external IP address is
+assigned to the VM.
+
+```
+[
+  {
+    "name": "//compute.googleapis.com/projects/test-project/zones/us-east1-b/instances/vm",
+    "asset_type": "google.compute.Instance",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+      "discovery_name": "Instance",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/68478495408",
+      "data": {
+        "name": "vm-external-ip",
+        "networkInterface": [
+          {
+            "accessConfig": [
+              {
+                "externalIp": "35.196.151.107",
+                "name": "external-nat",
+                "networkTier": "PREMIUM",
+                "type": "ONE_TO_ONE_NAT"
+              }
+            ],
+            "fingerprint": "FKYLBaTiCF0=",
+            "ipAddress": "10.142.0.2",
+            "name": "nic0",
+            "network": "https://www.googleapis.com/compute/v1/projects/test-project/global/networks/default",
+            "subnetwork": "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-east1/subnetworks/default"
+          }
+        ],
+      }
+    }
+  },
+]
+```
+
+#### Write Rego rule for constraint template
+
+In order to develop a constraint template, you must develop a Rego rule to back
+it. Before you begin, read about
+[how to write policies](https://www.openpolicyagent.org/docs/how-do-i-write-policies.html)
+using Rego and Open Policy Agent.
+
+To store a rule for your constraint template, create a new Rego file (for
+example, <code><em>vm_external_ip.rego</em></code>). This file should include a
+single <code><em>deny</em></code> rule which returns violations by evaluating
+whether a given <code><em>input.asset</em></code> violates the constraint
+provided in <code><em>input.constraint</em></code>.
+
+As you develop the Rego rule, keep these principles in mind:
+
+*   Logic can be externalized into additional rules and functions which should
+    be defined below the deny rule in a utilities section.
+*   If your rule only applies to particular resource types, you should check
+    that the given <code><em>input.asset</em></code> is of the required type
+    early on. (for example, <code><em>input.asset.asset_type ==
+    "google.compute.Instance"</em></code>).
+*   If your rule requires input parameters, they will be present under
+    <code>input.constraint</code>. You can retrieve it using the library
+    function <code>get_constraint_params</code> in the
+    <code>data.validator.gcp.lib</code> package.
+*   Comments should be included for any complicated logic and all helper
+    functions and rules should have a comment explaining their intent.
+*   Equality comparison should be done using <code><em>==</em></code> to
+    differentiate it from assignment.
+*   A violation is generated only when the rule body evaluates to true. In other
+    words, you should look for the negative condition.
+*   There are helpful functions available in the GCP library which you can
+    import into your rule. For example, <code><em>import data.validator.gcp.lib
+    as lib</em></code>.
+
+For example, this rule checks whether a VM with external IP address should be
+exempted (whitelist) or treated as a violation (blacklist):
+
+```
+package validator.gcp.GCPExternalIpAccessConstraintV1
+import data.validator.gcp.lib as lib
+
+deny[{
+        "msg": message,
+        "details": metadata,
+}] {
+        constraint := input.constraint
+        lib.get_constraint_params(constraint, params)
+        asset := input.asset
+        asset.asset_type == "google.compute.Instance"
+        # Find network access config block w/ external IP
+        instance := asset.resource.data
+        access_config := instance.networkInterface[_].accessConfig
+        external_ip := access_config[_].externalIp
+        # Check if instance is in blacklist/whitelist
+        target_instances := params.instances
+        matches := {asset.name} & cast_set(target_instances)
+        target_instance_match_count(params.mode, desired_count)
+        count(matches) == desired_count
+        message := sprintf("%v is not allowed to have an external IP.", [asset.name])
+        metadata := {"external_ip": external_ip}
+}
+
+# Determine the overlap between instances under test and constraint
+# By default (whitelist), we violate if there isn't overlap
+target_instance_match_count(mode) = 0 {
+        mode != "blacklist"
+}
+target_instance_match_count(mode) = 1 {
+        mode == "blacklist"
+}
+```
+
+#### Write constraint and resource fixtures for your constraint template
+
+To test your rule, create fixtures of the expected resources and constraints
+leveraging your rule. To implement your test cases, gather resource fixtures
+from CAI and place them in a
+<code><em>test/fixtures/resources/<resource_type>/data.json</em></code> file.
+You can also write a constraint fixture using your constraint template and place
+it in
+<code><em>test/fixtures/constraints/<constraint_name/data.yaml</em></code>.
+
+For example, here is a sample constraint used for external IP rule:
+
+```
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPExternalIpAccessConstraintV1
+metadata:
+  name: forbid-external-ip-whitelist
+spec:
+  severity: high
+  match:
+    target: ["organization/*"]
+  parameters:
+    mode: "whitelist"
+    instances:
+      - //compute.googleapis.com/projects/test-project/zones/us-east1-b/instances/vm-external-ip
+```
+
+The rule above says that the external IP constraint applies to all
+organizations, but the GCE instance `vm-external-ip` under `test-project` in
+`us-east1-b` is exempt.
+
+#### Write Rego tests for your rule
+
+As you develop your constraint template, implement test cases that ensure your
+logic doesn't break over time. Open Policy Agent allows you to
+[implement simple tests](https://www.openpolicyagent.org/docs/how-do-i-test-policies.html)
+by prefixing rules with `test_`.
+
+Using the fixtures you have gathered, write tests in a Rego file named after
+your rule. For example, <code><em>vm_external_ip_test.rego</em></code>. Make
+sure to place this Rego file in the same package as your rule with the
+<code>package</code> definition. One useful pattern is to write a rule which
+gathers all violations for your test cases and additional <code>test_</code>
+rules which verify those violations.
+
+For example, here are the tests for the above external IP constraint:
+
+```
+package validator.gcp.GCPExternalIpAccessConstraintV1
+
+import data.test.fixtures.assets.compute_instances as fixture_instances
+import data.test.fixtures.constraints as fixture_constraints
+
+# Find all violations on our test cases
+find_violations[violation] {
+        instance := data.instances[_]
+        constraint := data.test_constraints[_]
+        issues := deny with input.asset as instance
+                 with input.constraint as constraint
+        total_issues := count(issues)
+        violation := issues[_]
+}
+
+whitelist_violations[violation] {
+        constraints := [fixture_constraints.forbid_external_ip_whitelist]
+        found_violations := find_violations with data.instances as fixture_instances
+                 with data.test_constraints as constraints
+        violation := found_violations[_]
+}
+
+# Confirm only a single violation was found (whitelist constraint)
+test_external_whitelist_ip_violates_one {
+        found_violations := whitelist_violations
+        count(found_violations) = 1
+        violation := found_violations[_]
+        resource_name := "//compute.googleapis.com/projects/test-project/zones/us-east1-b/instances/vm-external-ip"
+        is_string(violation.msg)
+        is_object(violation.details)
+}
+
+```
+
+#### Create constraint template YAML definition
+
+Once you have a working Rego rule, you are ready to package it into a constraint
+template. You can do this by writing a YAML file which defines the expected
+parameters and logic for constraints. Create this file from the template, and
+then input the contents of your Rego rule.
+
+This example shows the external IP constraint template, with the italicized
+portions changing for your template:
+
+```
+apiVersion: templates.gatekeeper.sh/v1alpha1
+kind: ConstraintTemplate
+metadata:
+  name: gcp-external-ip-access
+  annotations:
+    # Example of tying a template to a CIS benchmark
+    benchmark: CIS11_5.03
+spec:
+  crd:
+    spec:
+      names:
+        kind: GCPExternalIpAccessConstraintV1
+        plural: gcpexternalipaccessconstraintsv1
+      validation:
+        openAPIV3Schema:
+          properties:
+            mode:
+              type: string
+              enum: [blacklist, whitelist]
+            instances:
+              type: array
+              items: string
+  targets:
+   validation.gcp.forsetisecurity.org:
+      rego: |
+            #INLINE("validator/vm_external_ip.rego")
+            #ENDINLINE
+```
+
+The Rego rule is supposed to be inlined in the YAML file. To do that, run `make
+build`. That will format the rego rules and inline them in the YAML files under
+the `#INLINE` directive.
+
+## Contact Info
+
+Questions or comments? Please contact validator-support@google.com.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -2,7 +2,7 @@
 
 ### Go from setup to proof-of-concept in under 1 hour
 
-*Table of Contents*
+**Table of Contents**
 
 * [Overview](#overview)
 * [How to set up constraints with Policy Library](#how-to-set-up-constraints-with-policy-library)

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -2,8 +2,7 @@
 
 ### Go from setup to proof-of-concept in under 1 hour
 
-Table of Contents
-=================
+*Table of Contents*
 
 * [Overview](#overview)
 * [How to set up constraints with Policy Library](#how-to-set-up-constraints-with-policy-library)

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,26 +1,26 @@
 ## Config Validator | Setup & User Guide
 
+### Go from setup to proof-of-concept in under 1 hour
+
 Table of Contents
 =================
 
-      * [Overview](#overview)
-      * [How to set up constraints with Policy Library](#how-to-set-up-constraints-with-policy-library)
-         * [Get started with the Policy Library repository](#get-started-with-the-policy-library-repository)
-         * [Instantiate constraints](#instantiate-constraints)
-      * [How to use Terraform Validator](#how-to-use-terraform-validator)
-         * [Install Terraform Validator](#install-terraform-validator)
-         * [For local development environments](#for-local-development-environments)
-         * [For Production Environments](#for-production-environments)
-      * [How to Use Forseti Config Validator](#how-to-use-forseti-config-validator)
-         * [Install Forseti](#install-forseti)
-         * [Copy over policy library repository](#copy-over-policy-library-repository)
-         * [How to change the run frequency of Forseti](#how-to-change-the-run-frequency-of-forseti)
-         * [How to handle scaling for large resource sets](#how-to-handle-scaling-for-large-resource-sets)
-         * [How to connect violation results with Cloud Security Command Center (CSCC)](#how-to-connect-violation-results-with-cloud-security-command-center-cscc)
-      * [End to end workflow with sample constraint](#end-to-end-workflow-with-sample-constraint)
-      * [Contact Info](#contact-info)
-
-### Go from setup to proof-of-concept in under 1 hour
+* [Overview](#overview)
+* [How to set up constraints with Policy Library](#how-to-set-up-constraints-with-policy-library)
+  * [Get started with the Policy Library repository](#get-started-with-the-policy-library-repository)
+  * [Instantiate constraints](#instantiate-constraints)
+* [How to use Terraform Validator](#how-to-use-terraform-validator)
+  * [Install Terraform Validator](#install-terraform-validator)
+  * [For local development environments](#for-local-development-environments)
+  * [For Production Environments](#for-production-environments)
+* [How to Use Forseti Config Validator](#how-to-use-forseti-config-validator)
+  * [Install Forseti](#install-forseti)
+  * [Copy over policy library repository](#copy-over-policy-library-repository)
+  * [How to change the run frequency of Forseti](#how-to-change-the-run-frequency-of-forseti)
+  * [How to handle scaling for large resource sets](#how-to-handle-scaling-for-large-resource-sets)
+  * [How to connect violation results with Cloud Security Command Center (CSCC)](#how-to-connect-violation-results-with-cloud-security-command-center-cscc)
+* [End to end workflow with sample constraint](#end-to-end-workflow-with-sample-constraint)
+* [Contact Info](#contact-info)
 
 ## Overview
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,5 +1,25 @@
 ## Config Validator | Setup & User Guide
 
+Table of Contents
+=================
+
+      * [Overview](#overview)
+      * [How to set up constraints with Policy Library](#how-to-set-up-constraints-with-policy-library)
+         * [Get started with the Policy Library repository](#get-started-with-the-policy-library-repository)
+         * [Instantiate constraints](#instantiate-constraints)
+      * [How to use Terraform Validator](#how-to-use-terraform-validator)
+         * [Install Terraform Validator](#install-terraform-validator)
+         * [For local development environments](#for-local-development-environments)
+         * [For Production Environments](#for-production-environments)
+      * [How to Use Forseti Config Validator](#how-to-use-forseti-config-validator)
+         * [Install Forseti](#install-forseti)
+         * [Copy over policy library repository](#copy-over-policy-library-repository)
+         * [How to change the run frequency of Forseti](#how-to-change-the-run-frequency-of-forseti)
+         * [How to handle scaling for large resource sets](#how-to-handle-scaling-for-large-resource-sets)
+         * [How to connect violation results with Cloud Security Command Center (CSCC)](#how-to-connect-violation-results-with-cloud-security-command-center-cscc)
+      * [End to end workflow with sample constraint](#end-to-end-workflow-with-sample-constraint)
+      * [Contact Info](#contact-info)
+
 ### Go from setup to proof-of-concept in under 1 hour
 
 ## Overview
@@ -24,7 +44,7 @@ pre-deployment and monitoring tools. These constraints live in your
 organization's repository as the source of truth for your security and
 governance requirements. You can obtain constraints from the
 [Policy Library](#how-to-set-up-constraints-with-policy-library), or
-[build your own constraints](#how-to-build-your-own-custom-constraint-templates).
+[build your own constraint templates](constraint_template_authoring.md).
 
 **Pre-deployment check**
 
@@ -520,312 +540,6 @@ terraform plan -out=test.tfplan
 ```
 
 The command above should result in no violations found.
-
-## How to build your own custom constraint templates
-
-This section is only applicable to advanced users who wish to create custom
-constraint templates. If the existing templates are sufficient, you can skip
-this section.
-
-#### Template Authoring Convention
-
-##### Naming
-
-The template name appears in three places in a template YAML file:
-
-*   metadata name: All lower case with "-" as the separator. It has the format
-    of "gcp-{resource}-{feature}-{version}" (example: "gcp-storage-logging-v1").
-*   CRD kind (under "spec" > "crd" > "spec" > "names" > "kind"): Camel case. It
-    has the format of "GCP{resource}{feature}Constraint{version}" (example:
-    "GCPStorageLoggingConstraintV1").
-*   CRD plural name (under "spec" > "crd" > "spec" > "names" > "plural"): Same
-    as CRD kind but in all lower case with the word "constraints" replacing
-    "constraint" (example: "gcpstorageloggingconstraintsv1")
-
-Wherever possible, follow [gcloud](https://cloud.google.com/sdk/gcloud/) group
-names for resource naming. For example, use "compute" instead of "gce", "sql"
-instead of "cloud-sql", and "container-cluster" instead of "gke".
-
-If a template applies to more than one type of resource, omit the resource part
-and only include the feature (example: "GCPExernalIPAccessV1").
-
-The version number does not follow semver form - it is just a single number.
-This effectively makes every version of a template an unique template. See
-[Constraint Framework: Versioning](https://docs.google.com/document/d/1vB_2wm60WCVLXoegMrupqwqKAuW6gbwEIxg3vBQj6cs/edit#)
-for reasons behind this convention.
-
-The configuration YAML file name should take after the metadata name and replace
-"-" with "_" (example: "gcp_storage_logging_v1.yaml").
-
-##### Commentary
-
-Every configuration YAML file should have a summary at the top to describe the
-constraint. In the parameters section, every parameter should have a preceding
-comment to explain what the parameter does.
-
-#### Validate your constraint goals and target resources
-
-Before beginning to develop your constraint template, you should write a
-concrete definition of your goals in plain language. In writing this definition,
-clearly define what resources you're looking to scan or analyze, and what
-properties of those resources you plan to constrain.
-
-For example:
-
-```
-The External IP Access Constraint will scan GCP VM instances and validate that the Access Config of their network interface does not include an external IP address.
-```
-
-#### Gather sample resource data
-
-Before proceeding to develop your template, you should verify that Cloud Asset
-Inventory
-[supports](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview#supported_resource_types)
-the resources you want. Assuming it does, you should gather some sample data to
-use in developing and testing your rule by creating resources of the appropriate
-type and creating a CAI export of those resources (see
-[CAI quickstart](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/quickstart-cloud-asset-inventory)).
-If the desired resource is not supported, please open a GitHub issue and/or
-email validator-support@google.com.
-
-For example, you might gather the following JSON export for external IP address
-constraint (for brevity, most fields are omitted). In the same data below, the
-presence of the `externalIp` field indicates that an external IP address is
-assigned to the VM.
-
-```
-[
-  {
-    "name": "//compute.googleapis.com/projects/test-project/zones/us-east1-b/instances/vm",
-    "asset_type": "google.compute.Instance",
-    "resource": {
-      "version": "v1",
-      "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
-      "discovery_name": "Instance",
-      "parent": "//cloudresourcemanager.googleapis.com/projects/68478495408",
-      "data": {
-        "name": "vm-external-ip",
-        "networkInterface": [
-          {
-            "accessConfig": [
-              {
-                "externalIp": "35.196.151.107",
-                "name": "external-nat",
-                "networkTier": "PREMIUM",
-                "type": "ONE_TO_ONE_NAT"
-              }
-            ],
-            "fingerprint": "FKYLBaTiCF0=",
-            "ipAddress": "10.142.0.2",
-            "name": "nic0",
-            "network": "https://www.googleapis.com/compute/v1/projects/test-project/global/networks/default",
-            "subnetwork": "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-east1/subnetworks/default"
-          }
-        ],
-      }
-    }
-  },
-]
-```
-
-#### Write Rego rule for constraint template
-
-In order to develop a constraint template, you must develop a Rego rule to back
-it. Before you begin, read about
-[how to write policies](https://www.openpolicyagent.org/docs/how-do-i-write-policies.html)
-using Rego and Open Policy Agent.
-
-To store a rule for your constraint template, create a new Rego file (for
-example, <code><em>vm_external_ip.rego</em></code>). This file should include a
-single <code><em>deny</em></code> rule which returns violations by evaluating
-whether a given <code><em>input.asset</em></code> violates the constraint
-provided in <code><em>input.constraint</em></code>.
-
-As you develop the Rego rule, keep these principles in mind:
-
-*   Logic can be externalized into additional rules and functions which should
-    be defined below the deny rule in a utilities section.
-*   If your rule only applies to particular resource types, you should check
-    that the given <code><em>input.asset</em></code> is of the required type
-    early on. (for example, <code><em>input.asset.asset_type ==
-    "google.compute.Instance"</em></code>).
-*   If your rule requires input parameters, they will be present under
-    <code>input.constraint</code>. You can retrieve it using the library
-    function <code>get_constraint_params</code> in the
-    <code>data.validator.gcp.lib</code> package.
-*   Comments should be included for any complicated logic and all helper
-    functions and rules should have a comment explaining their intent.
-*   Equality comparison should be done using <code><em>==</em></code> to
-    differentiate it from assignment.
-*   A violation is generated only when the rule body evaluates to true. In other
-    words, you should look for the negative condition.
-*   There are helpful functions available in the GCP library which you can
-    import into your rule. For example, <code><em>import data.validator.gcp.lib
-    as lib</em></code>.
-
-For example, this rule checks whether a VM with external IP address should be
-exempted (whitelist) or treated as a violation (blacklist):
-
-```
-package validator.gcp.GCPExternalIpAccessConstraintV1
-import data.validator.gcp.lib as lib
-
-deny[{
-        "msg": message,
-        "details": metadata,
-}] {
-        constraint := input.constraint
-        lib.get_constraint_params(constraint, params)
-        asset := input.asset
-        asset.asset_type == "google.compute.Instance"
-        # Find network access config block w/ external IP
-        instance := asset.resource.data
-        access_config := instance.networkInterface[_].accessConfig
-        external_ip := access_config[_].externalIp
-        # Check if instance is in blacklist/whitelist
-        target_instances := params.instances
-        matches := {asset.name} & cast_set(target_instances)
-        target_instance_match_count(params.mode, desired_count)
-        count(matches) == desired_count
-        message := sprintf("%v is not allowed to have an external IP.", [asset.name])
-        metadata := {"external_ip": external_ip}
-}
-
-# Determine the overlap between instances under test and constraint
-# By default (whitelist), we violate if there isn't overlap
-target_instance_match_count(mode) = 0 {
-        mode != "blacklist"
-}
-target_instance_match_count(mode) = 1 {
-        mode == "blacklist"
-}
-```
-
-#### Write constraint and resource fixtures for your constraint template
-
-To test your rule, create fixtures of the expected resources and constraints
-leveraging your rule. To implement your test cases, gather resource fixtures
-from CAI and place them in a
-<code><em>test/fixtures/resources/<resource_type>/data.json</em></code> file.
-You can also write a constraint fixture using your constraint template and place
-it in
-<code><em>test/fixtures/constraints/<constraint_name/data.yaml</em></code>.
-
-For example, here is a sample constraint used for external IP rule:
-
-```
-apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPExternalIpAccessConstraintV1
-metadata:
-  name: forbid-external-ip-whitelist
-spec:
-  severity: high
-  match:
-    target: ["organization/*"]
-  parameters:
-    mode: "whitelist"
-    instances:
-      - //compute.googleapis.com/projects/test-project/zones/us-east1-b/instances/vm-external-ip
-```
-
-The rule above says that the external IP constraint applies to all
-organizations, but the GCE instance `vm-external-ip` under `test-project` in
-`us-east1-b` is exempt.
-
-#### Write Rego tests for your rule
-
-As you develop your constraint template, implement test cases that ensure your
-logic doesn't break over time. Open Policy Agent allows you to
-[implement simple tests](https://www.openpolicyagent.org/docs/how-do-i-test-policies.html)
-by prefixing rules with `test_`.
-
-Using the fixtures you have gathered, write tests in a Rego file named after
-your rule. For example, <code><em>vm_external_ip_test.rego</em></code>. Make
-sure to place this Rego file in the same package as your rule with the
-<code>package</code> definition. One useful pattern is to write a rule which
-gathers all violations for your test cases and additional <code>test_</code>
-rules which verify those violations.
-
-For example, here are the tests for the above external IP constraint:
-
-```
-package validator.gcp.GCPExternalIpAccessConstraintV1
-
-import data.test.fixtures.assets.compute_instances as fixture_instances
-import data.test.fixtures.constraints as fixture_constraints
-
-# Find all violations on our test cases
-find_violations[violation] {
-        instance := data.instances[_]
-        constraint := data.test_constraints[_]
-        issues := deny with input.asset as instance
-                 with input.constraint as constraint
-        total_issues := count(issues)
-        violation := issues[_]
-}
-
-whitelist_violations[violation] {
-        constraints := [fixture_constraints.forbid_external_ip_whitelist]
-        found_violations := find_violations with data.instances as fixture_instances
-                 with data.test_constraints as constraints
-        violation := found_violations[_]
-}
-
-# Confirm only a single violation was found (whitelist constraint)
-test_external_whitelist_ip_violates_one {
-        found_violations := whitelist_violations
-        count(found_violations) = 1
-        violation := found_violations[_]
-        resource_name := "//compute.googleapis.com/projects/test-project/zones/us-east1-b/instances/vm-external-ip"
-        is_string(violation.msg)
-        is_object(violation.details)
-}
-
-```
-
-#### Create constraint template YAML definition
-
-Once you have a working Rego rule, you are ready to package it into a constraint
-template. You can do this by writing a YAML file which defines the expected
-parameters and logic for constraints. Create this file from the template, and
-then input the contents of your Rego rule.
-
-This example shows the external IP constraint template, with the italicized
-portions changing for your template:
-
-```
-apiVersion: templates.gatekeeper.sh/v1alpha1
-kind: ConstraintTemplate
-metadata:
-  name: gcp-external-ip-access
-  annotations:
-    # Example of tying a template to a CIS benchmark
-    benchmark: CIS11_5.03
-spec:
-  crd:
-    spec:
-      names:
-        kind: GCPExternalIpAccessConstraintV1
-        plural: gcpexternalipaccessconstraintsv1
-      validation:
-        openAPIV3Schema:
-          properties:
-            mode:
-              type: string
-              enum: [blacklist, whitelist]
-            instances:
-              type: array
-              items: string
-  targets:
-   validation.gcp.forsetisecurity.org:
-      rego: |
-            #INLINE("validator/vm_external_ip.rego")
-            #ENDINLINE
-```
-
-The Rego rule is supposed to be inlined in the YAML file. To do that, run `make
-build`. That will format the rego rules and inline them in the YAML files under
-the `#INLINE` directive.
 
 ## Contact Info
 


### PR DESCRIPTION
Also add TOC. Original issue: https://github.com/forseti-security/config-validator/issues/21