### PR TITLE
Fix indentation on template .yaml files

### DIFF
--- a/policies/templates/gcp_cmek_rotation_v1.yaml
+++ b/policies/templates/gcp_cmek_rotation_v1.yaml
@@ -26,9 +26,9 @@ spec:
         openAPIV3Schema:
           properties: {}
   targets:
-   validation.gcp.forsetisecurity.org:
+    validation.gcp.forsetisecurity.org:
       rego: |
-            #INLINE("validator/cmek_rotation.rego")
+           #INLINE("validator/cmek_rotation.rego")
            #
            # Copyright 2018 Google LLC
            #

--- a/policies/templates/gcp_glb_external_ip_access_constraint_v1.yaml
+++ b/policies/templates/gcp_glb_external_ip_access_constraint_v1.yaml
@@ -34,9 +34,9 @@ spec:
               type: array
               items: string
   targets:
-   validation.gcp.forsetisecurity.org:
+    validation.gcp.forsetisecurity.org:
       rego: |
-            #INLINE("validator/gcp_glb_external_ip.rego")
+           #INLINE("validator/gcp_glb_external_ip.rego")
            #
            # Copyright 2018 Google LLC
            #

--- a/policies/templates/gcp_sql_public_ip_v1.yaml
+++ b/policies/templates/gcp_sql_public_ip_v1.yaml
@@ -26,9 +26,9 @@ spec:
         openAPIV3Schema:
           properties: {}
   targets:
-   validation.gcp.forsetisecurity.org:
+    validation.gcp.forsetisecurity.org:
       rego: |
-            #INLINE("validator/sql_public_ip.rego")
+           #INLINE("validator/sql_public_ip.rego")
            #
            # Copyright 2018 Google LLC
            #


### PR DESCRIPTION
The position of the INLINE directive comment was causing the following errors:
```
ERROR: logging before flag.Parse: I0523 14:04:47.741779   17479 validator.go:116] Unable to convert file config-validator/release/policy-library/policies/templates/gcp_cmek_rotation_v1.yaml, with error unmarshal []byte to yaml failed: yaml: line 46: did not find expected key, assuming this file should be skipped and continuing
ERROR: logging before flag.Parse: I0523 14:04:47.742214   17479 validator.go:116] Unable to convert file config-validator/release/policy-library/policies/templates/gcp_glb_external_ip_access_constraint_v1.yaml, with error unmarshal []byte to yaml failed: yaml: line 55: did not find expected key, assuming this file should be skipped and continuing
ERROR: logging before flag.Parse: I0523 14:04:47.742785   17479 validator.go:116] Unable to convert file config-validator/release/policy-library/policies/templates/gcp_sql_public_ip_v1.yaml, with error unmarshal []byte to yaml failed: yaml: line 47: did not find expected key, assuming this file should be skipped and continuing
```