### PR TITLE
move inline comment directive to be in the same line as the pipe

### DIFF
--- a/policies/templates/gcp_always_violates_v1.yaml
+++ b/policies/templates/gcp_always_violates_v1.yaml
@@ -27,8 +27,7 @@ spec:
           properties: {}
   targets:
    validation.gcp.forsetisecurity.org:
-      rego: |
-           #INLINE("validator/always_violates.rego")
+      rego: | #INLINE("validator/always_violates.rego")
            #
            # Copyright 2018 Google LLC
            #

--- a/policies/templates/gcp_bq_dataset_location_v1.yaml
+++ b/policies/templates/gcp_bq_dataset_location_v1.yaml
@@ -49,8 +49,7 @@ spec:
               (e.g. us-west2) or multi-regional (e.g. EU), as defined at https://cloud.google.com/bigquery/docs/locations."
   targets:
     validation.gcp.forsetisecurity.org:
-      rego: |
-            #INLINE("validator/bq_dataset_location.rego")
+      rego: | #INLINE("validator/bq_dataset_location.rego")
            
            #
            

--- a/policies/templates/gcp_cmek_rotation_v1.yaml
+++ b/policies/templates/gcp_cmek_rotation_v1.yaml
@@ -27,8 +27,7 @@ spec:
           properties: {}
   targets:
     validation.gcp.forsetisecurity.org:
-      rego: |
-           #INLINE("validator/cmek_rotation.rego")
+      rego: | #INLINE("validator/cmek_rotation.rego")
            #
            # Copyright 2018 Google LLC
            #

--- a/policies/templates/gcp_compute_zone_v1.yaml
+++ b/policies/templates/gcp_compute_zone_v1.yaml
@@ -50,8 +50,7 @@ spec:
               e.g. asia-east1-b."
   targets:
     validation.gcp.forsetisecurity.org:
-      rego: |
-           #INLINE("validator/compute_zone.rego")
+      rego: | #INLINE("validator/compute_zone.rego")
            #
            # Copyright 2019 Google LLC
            #

--- a/policies/templates/gcp_dnssec_v1.yaml
+++ b/policies/templates/gcp_dnssec_v1.yaml
@@ -27,8 +27,7 @@ spec:
           properties: {}
   targets:
     validation.gcp.forsetisecurity.org:
-      rego: |
-            #INLINE("validator/dnssec.rego")
+      rego: | #INLINE("validator/dnssec.rego")
             #
             # Copyright 2018 Google LLC
             #

--- a/policies/templates/gcp_external_ip_access_v1.yaml
+++ b/policies/templates/gcp_external_ip_access_v1.yaml
@@ -36,8 +36,7 @@ spec:
               items: string
   targets:
    validation.gcp.forsetisecurity.org:
-      rego: |
-            #INLINE("validator/vm_external_ip.rego")
+      rego: | #INLINE("validator/vm_external_ip.rego")
             #
             # Copyright 2018 Google LLC
             #

--- a/policies/templates/gcp_gke_dashboard_v1.yaml
+++ b/policies/templates/gcp_gke_dashboard_v1.yaml
@@ -29,8 +29,7 @@ spec:
           properties: {}
   targets:
     validation.gcp.forsetisecurity.org:
-      rego: |
-            #INLINE("validator/gke_dashboard.rego")
+      rego: | #INLINE("validator/gke_dashboard.rego")
             #
             # Copyright 2018 Google LLC
             #

--- a/policies/templates/gcp_gke_legacy_abac_v1.yaml
+++ b/policies/templates/gcp_gke_legacy_abac_v1.yaml
@@ -29,8 +29,7 @@ spec:
           properties: {}
   targets:
     validation.gcp.forsetisecurity.org:
-      rego: |
-        #INLINE("validator/gke_legacy_abac.rego")
+      rego: | #INLINE("validator/gke_legacy_abac.rego")
         #
         # Copyright 2018 Google LLC
         #

--- a/policies/templates/gcp_gke_restrict_pod_traffic_v1.yaml
+++ b/policies/templates/gcp_gke_restrict_pod_traffic_v1.yaml
@@ -29,8 +29,7 @@ spec:
           properties: {}
   targets:
     validation.gcp.forsetisecurity.org:
-      rego: |
-         #INLINE("validator/gke_restrict_pod_traffic.rego")
+      rego: | #INLINE("validator/gke_restrict_pod_traffic.rego")
          #
          # Copyright 2018 Google LLC
          #

--- a/policies/templates/gcp_glb_external_ip_access_constraint_v1.yaml
+++ b/policies/templates/gcp_glb_external_ip_access_constraint_v1.yaml
@@ -35,8 +35,7 @@ spec:
               items: string
   targets:
     validation.gcp.forsetisecurity.org:
-      rego: |
-           #INLINE("validator/gcp_glb_external_ip.rego")
+      rego: |#INLINE("validator/gcp_glb_external_ip.rego")
            #
            # Copyright 2018 Google LLC
            #

--- a/policies/templates/gcp_iam_allowed_bindings_v1.yaml
+++ b/policies/templates/gcp_iam_allowed_bindings_v1.yaml
@@ -40,8 +40,7 @@ spec:
               items: string
   targets:
    validation.gcp.forsetisecurity.org:
-      rego: |
-            #INLINE("validator/iam_allowed_bindings.rego")
+      rego: | #INLINE("validator/iam_allowed_bindings.rego")
             #
             # Copyright 2019 Google LLC
             #

--- a/policies/templates/gcp_iam_allowed_policy_member_domains.yaml
+++ b/policies/templates/gcp_iam_allowed_policy_member_domains.yaml
@@ -48,8 +48,7 @@ spec:
               items: string
   targets:
    validation.gcp.forsetisecurity.org:
-      rego: |
-            #INLINE("validator/iam_allowed_policy_member_domains.rego")
+      rego: | #INLINE("validator/iam_allowed_policy_member_domains.rego")
             #
             # Copyright 2019 Google LLC
             #

--- a/policies/templates/gcp_iam_restrict_service_account_creation_v1.yaml
+++ b/policies/templates/gcp_iam_restrict_service_account_creation_v1.yaml
@@ -27,8 +27,7 @@ spec:
           properties: {}
   targets:
    validation.gcp.forsetisecurity.org:
-      rego: |
-          #INLINE("validator/gcp_iam_restrict_service_account_creation.rego")
+      rego: | #INLINE("validator/gcp_iam_restrict_service_account_creation.rego")
           # Copyright 2019 Google LLC
           #
           # Licensed under the Apache License, Version 2.0 (the "License");

--- a/policies/templates/gcp_network_routing_v1.yaml
+++ b/policies/templates/gcp_network_routing_v1.yaml
@@ -29,8 +29,7 @@ spec:
             default: GLOBAL
   targets:
     validation.gcp.forsetisecurity.org:
-      rego: |
-            #INLINE("validator/network_routing.rego")
+      rego: | #INLINE("validator/network_routing.rego")
             #
             # Copyright 2018 Google LLC
             #

--- a/policies/templates/gcp_serviceusage_allowed_services_v1.yaml
+++ b/policies/templates/gcp_serviceusage_allowed_services_v1.yaml
@@ -35,8 +35,7 @@ spec:
               items: string
   targets:
     validation.gcp.forsetisecurity.org:
-      rego: |
-            #INLINE("validator/serviceusage_service.rego")
+      rego: | #INLINE("validator/serviceusage_service.rego")
             #
             # Copyright 2018 Google LLC
             #

--- a/policies/templates/gcp_sql_allowed_authorized_networks_v1.yaml
+++ b/policies/templates/gcp_sql_allowed_authorized_networks_v1.yaml
@@ -39,8 +39,7 @@ spec:
 
   targets:
    validation.gcp.forsetisecurity.org:
-      rego: |
-            #INLINE("validator/sql_allowed_authorized_networks.rego")
+      rego: | #INLINE("validator/sql_allowed_authorized_networks.rego")
             #
             # Copyright 2018 Google LLC
             #

--- a/policies/templates/gcp_sql_public_ip_v1.yaml
+++ b/policies/templates/gcp_sql_public_ip_v1.yaml
@@ -27,8 +27,7 @@ spec:
           properties: {}
   targets:
     validation.gcp.forsetisecurity.org:
-      rego: |
-           #INLINE("validator/sql_public_ip.rego")
+      rego: | #INLINE("validator/sql_public_ip.rego")
            #
            # Copyright 2018 Google LLC
            #

--- a/policies/templates/gcp_sql_ssl_v1.yaml
+++ b/policies/templates/gcp_sql_ssl_v1.yaml
@@ -27,8 +27,7 @@ spec:
           properties: {}
   targets:
    validation.gcp.forsetisecurity.org:
-      rego: |
-            #INLINE("validator/sql_ssl.rego")
+      rego: | #INLINE("validator/sql_ssl.rego")
 
             #
 

--- a/policies/templates/gcp_storage_bucket_world_readable_v1.yaml
+++ b/policies/templates/gcp_storage_bucket_world_readable_v1.yaml
@@ -27,8 +27,7 @@ spec:
           properties: {}
   targets:
    validation.gcp.forsetisecurity.org:
-      rego: |
-           #INLINE("validator/storage_bucket_world_readable.rego")
+      rego: | #INLINE("validator/storage_bucket_world_readable.rego")
            #
            # Copyright 2018 Google LLC
            #

--- a/policies/templates/gcp_storage_cmek_encryption_v1.yaml
+++ b/policies/templates/gcp_storage_cmek_encryption_v1.yaml
@@ -27,8 +27,7 @@ spec:
           properties: {}
   targets:
    validation.gcp.forsetisecurity.org:
-      rego: |
-            #INLINE("validator/storage_cmek_encryption.rego")
+      rego: | #INLINE("validator/storage_cmek_encryption.rego")
             #
             # Copyright 2019 Google LLC
             #

--- a/policies/templates/gcp_storage_logging_v1.yaml
+++ b/policies/templates/gcp_storage_logging_v1.yaml
@@ -27,8 +27,7 @@ spec:
           properties: {}
   targets:
    validation.gcp.forsetisecurity.org:
-      rego: |
-            #INLINE("validator/storage_logging.rego")
+      rego: | #INLINE("validator/storage_logging.rego")
             #
             # Copyright 2018 Google LLC
             #


### PR DESCRIPTION
So that we don't run into the following yaml parsing issue:
```
ERROR: logging before flag.Parse: I0603 15:52:13.667529  216768 validator.go:116] Unable to convert file policy-library/policies/templates/gcp_bq_dataset_location_v1.yaml, with error unmarshal []byte to yaml failed: yaml: line 86: did not find expected key, assuming this file should be skipped and continuing
```