### PR TITLE
update violation metadata to include resource name for IAM constraints

### DIFF
--- a/policies/templates/gcp_iam_allowed_bindings_v1.yaml
+++ b/policies/templates/gcp_iam_allowed_bindings_v1.yaml
@@ -84,6 +84,7 @@ spec:
             	message := sprintf("IAM policy for %v grants %v to %v", [asset.name, role, member])
             
             	metadata := {
+            		"resource": asset.name,
             		"member": member,
             		"role": role,
             	}

--- a/policies/templates/gcp_iam_allowed_policy_member_domains.yaml
+++ b/policies/templates/gcp_iam_allowed_policy_member_domains.yaml
@@ -87,7 +87,7 @@ spec:
             
             	message := sprintf("IAM policy for %v contains member from unexpected domain: %v", [asset.name, member])
             
-            	metadata := {"member": member}
+            	metadata := {"resource": asset.name, "member": member}
             }
             
             starts_with_whitelisted_type(whitelist, member) {

--- a/validator/iam_allowed_bindings.rego
+++ b/validator/iam_allowed_bindings.rego
@@ -41,6 +41,7 @@ deny[{
 	message := sprintf("IAM policy for %v grants %v to %v", [asset.name, role, member])
 
 	metadata := {
+		"resource": asset.name,
 		"member": member,
 		"role": role,
 	}

--- a/validator/iam_allowed_policy_member_domains.rego
+++ b/validator/iam_allowed_policy_member_domains.rego
@@ -36,7 +36,7 @@ deny[{
 
 	message := sprintf("IAM policy for %v contains member from unexpected domain: %v", [asset.name, member])
 
-	metadata := {"member": member}
+	metadata := {"resource": asset.name, "member": member}
 }
 
 starts_with_whitelisted_type(whitelist, member) {


### PR DESCRIPTION
update violation metadata to include resource name for IAM constraints GCPIAMAllowedBindingsConstraintV1 and GCPIAMAllowedPolicyMemberDomainsConstraintV1