### PR TITLE
Update plural names in templates to be all lowercase

### DIFF
--- a/policies/templates/gcp_gke_allowed_node_sa_v1.yaml
+++ b/policies/templates/gcp_gke_allowed_node_sa_v1.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       names:
         kind: GCPGKEAllowedNodeSAConstraintV1
-        plural: GCPGKEAllowedodeSAConstraintsV1
+        plural: gcpgkeallowedodesaconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_gke_dashboard_v1.yaml
+++ b/policies/templates/gcp_gke_dashboard_v1.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       names:
         kind: GCPGKEDashboardConstraintV1
-        plural: GCPGKEDashboardConstraintsV1
+        plural: gcpgkedashboardconstraintsv1        
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_gke_legacy_abac_v1.yaml
+++ b/policies/templates/gcp_gke_legacy_abac_v1.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       names:
         kind: GCPGKELegacyAbacConstraintV1
-        plural: GCPGKELegacyAbacConstraintsV1
+        plural: gcpgkelegacyabacconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_gke_node_auto_upgrade_v1.yaml
+++ b/policies/templates/gcp_gke_node_auto_upgrade_v1.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       names:
         kind: GCPGKENodeAutoUpgradeConstraintV1
-        plural: GCPGKENodeAutoUpgradeConstraintsV1
+        plural: gcpgkenodeautoupgradeconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_gke_restrict_pod_traffic_v1.yaml
+++ b/policies/templates/gcp_gke_restrict_pod_traffic_v1.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       names:
         kind: GCPGKERestrictPodTrafficConstraintV1
-        plural: GCPGKERestrictPodTrafficConstraintsV1
+        plural: gcpgkerestrictpodtrafficconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_glb_external_ip_access_constraint_v1.yaml
+++ b/policies/templates/gcp_glb_external_ip_access_constraint_v1.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       names:
         kind: GCPGLBExternalIpAccessConstraintV1
-        plural: GCPGLBExternalIpAccessConstraintv1
+        plural: gcpglbexternalipaccessconstraintv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_storage_bucket_world_readable_v1.yaml
+++ b/policies/templates/gcp_storage_bucket_world_readable_v1.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       names:
         kind: GCPStorageBucketWorldReadableConstraintV1
-        plural: GCPStorageBucketWorldReadableConstraintV1
+        plural: gcpstoragebucketworldreadableconstraintv1
       validation:
         openAPIV3Schema:
           properties: {}


### PR DESCRIPTION
Per https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#customresourcedefinition-v1beta1-apiextensions-k8s-io, the plural name must be all lowercase.

Also rename the GKE service account scope template file (only the file name is changed, so it should still be backwards compatible)