### PR TITLE
Add --explain=notes flag for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SHELL := /usr/bin/env bash
 .PHONY: test
 test: ## Test constraint templates via OPA
 	@echo "Running OPA tests..."
-	@opa test -v lib/ validator/
+	@opa test -v lib/ validator/ --explain=notes
 
 .PHONY: debug
 debug: ## Show debugging output from OPA


### PR DESCRIPTION
Adds the explain flag from https://github.com/open-policy-agent/opa/issues/1377 to the `make test` command.