### PR TITLE
enforce_label update: Adding new features + new resource types

### DIFF
--- a/policies/templates/gcp_enforce_labels_v1.yaml
+++ b/policies/templates/gcp_enforce_labels_v1.yaml
@@ -110,7 +110,8 @@ spec:
        
        	resource_types_to_scan := lib.get_default(params, "resource_types_to_scan", tested_resource_types)
        
-       	resource_is_to_scan(asset, resource_types_to_scan)
+       	# test if resource needs to be scanned
+       	resource_types_to_scan[_] == asset.asset_type
        
        	not label_is_valid(label_key, label_value_pattern, asset, standard_types)
        
@@ -118,11 +119,7 @@ spec:
        	metadata := {"resource": asset.name, "label_in_violation": label_key}
        }
        
-       resource_is_to_scan(asset, resource_types_to_scan) {
-       	resource_types_to_scan[_] == asset.asset_type
-       }
-       
-       # check if label exists for all resources to scan
+       # check if label exists and if its value matches the pattern passed as a parameter for all resources to scan
        label_is_valid(label_key, label_value_pattern, asset, standard_types) {
        	# retrieve the right values from asset
        	resource_labels := get_labels(asset, standard_types)

--- a/policies/templates/gcp_enforce_labels_v1.yaml
+++ b/policies/templates/gcp_enforce_labels_v1.yaml
@@ -99,13 +99,21 @@ spec:
        		"sqladmin.googleapis.com/Instance",
        	]
        
-       	non_standard_types := ["sqladmin.googleapis.com/Instance"]
+       	standard_types := [
+       		"cloudresourcemanager.googleapis.com/Project",
+       		"storage.googleapis.com/Bucket",
+       		"compute.googleapis.com/Instance",
+       		"compute.googleapis.com/Image",
+       		"compute.googleapis.com/Disk",
+       		"compute.googleapis.com/Snapshot",
+       		"google.bigtable.Instance",
+       	]
        
        	resource_types_to_scan := lib.get_default(params, "resource_types_to_scan", tested_resource_types)
        
        	resource_is_to_scan(asset, resource_types_to_scan)
        
-       	not label_is_valid(label_key, label_value_pattern, asset, non_standard_types)
+       	not label_is_valid(label_key, label_value_pattern, asset, standard_types)
        
        	message := sprintf("%v's label is in violation.", [asset.name])
        	metadata := {"resource": asset.name, "label_in_violation": label_key}
@@ -116,9 +124,9 @@ spec:
        }
        
        # check if label exists for all resources to scan
-       label_is_valid(label_key, label_value_pattern, asset, non_standard_types) {
+       label_is_valid(label_key, label_value_pattern, asset, standard_types) {
        	# retrieve the right values from asset
-       	resource_labels := get_labels(asset, non_standard_types)
+       	resource_labels := get_labels(asset, standard_types)
        
        	# test if label exists in asset
        	resource_labels[label_key]
@@ -128,14 +136,14 @@ spec:
        }
        
        # get_labels for standard resources
-       get_labels(asset, non_standard_types) = resource_labels {
-       	asset.asset_type != non_standard_types[_]
+       get_labels(asset, standard_types) = resource_labels {
+       	asset.asset_type == standard_types[_]
        	resource := asset.resource.data
        	resource_labels := lib.get_default(resource, "labels", {})
        }
        
        # get_labels for cloudsql instances
-       get_labels(asset, non_standard_types) = resource_labels {
+       get_labels(asset, standard_types) = resource_labels {
        	asset.asset_type == "sqladmin.googleapis.com/Instance"
        	resource := asset.resource.data.settings
        	resource_labels := lib.get_default(resource, "userLabels", {})

--- a/policies/templates/gcp_enforce_labels_v1.yaml
+++ b/policies/templates/gcp_enforce_labels_v1.yaml
@@ -35,13 +35,25 @@ spec:
                 "
               type: array
               items: objects
+              required: true
             resource_types_to_scan:
               description: | 
                 "Optional parameter: list of resource types to scan for labels.
                 Any resource that is not of these types will not raise any violation.
-                if not passed, all tested resource types will be scanned for violations (see below for full list)"
+                if not passed, all tested resource types will be scanned for violations:
+
+                - cloudresourcemanager.googleapis.com/Project
+                - storage.googleapis.com/Bucket
+                - compute.googleapis.com/Instance
+                - compute.googleapis.com/Image
+                - compute.googleapis.com/Disk
+                - compute.googleapis.com/Snapshot
+                - google.bigtable.Instance
+                - sqladmin.googleapis.com/Instance
+                "
               type: array
               items: string
+              required: false
   targets:
     validation.gcp.forsetisecurity.org:
       rego: | #INLINE("validator/enforce_labels.rego")
@@ -122,7 +134,7 @@ spec:
        	resource_labels := lib.get_default(resource, "labels", {})
        }
        
-       # ge_labels for cloudsql instances
+       # get_labels for cloudsql instances
        get_labels(asset, non_standard_types) = resource_labels {
        	asset.asset_type == "sqladmin.googleapis.com/Instance"
        	resource := asset.resource.data.settings

--- a/policies/templates/gcp_enforce_labels_v1.yaml
+++ b/policies/templates/gcp_enforce_labels_v1.yaml
@@ -15,7 +15,7 @@
 apiVersion: templates.gatekeeper.sh/v1alpha1
 kind: ConstraintTemplate
 metadata:
-  name: gcp-enforce_label-v1
+  name: gcp-enforce-labels-v1
 spec:
   crd:
     spec:
@@ -52,15 +52,6 @@ spec:
      
      import data.validator.gcp.lib as lib
      
-     resource_types_to_scan = [
-     	"cloudresourcemanager.googleapis.com/Project",
-     	"storage.googleapis.com/Bucket",
-     	"compute.googleapis.com/Instance",
-     	"compute.googleapis.com/Image",
-     	"compute.googleapis.com/Disk",
-     	"compute.googleapis.com/Snapshot",
-     ]
-     
      deny[{
      	"msg": message,
      	"details": metadata,
@@ -70,7 +61,20 @@ spec:
      	asset := input.asset
      
      	mandatory_labels := params.mandatory_labels[_]
-     	resource_is_to_scan(asset)
+     
+     	tested_resource_types := [
+     		"cloudresourcemanager.googleapis.com/Project",
+     		"storage.googleapis.com/Bucket",
+     		"compute.googleapis.com/Instance",
+     		"compute.googleapis.com/Image",
+     		"compute.googleapis.com/Disk",
+     		"compute.googleapis.com/Snapshot",
+     		"google.bigtable.Instance",
+     	]
+     
+     	resource_types_to_scan := lib.get_default(params, "resource_types_to_scan", tested_resource_types)
+     
+     	resource_is_to_scan(asset, resource_types_to_scan)
      	not label_is_valid(mandatory_labels, asset)
      
      	message := sprintf("%v doesn't have a required label.", [asset.name])
@@ -78,7 +82,7 @@ spec:
      	metadata := {"resource": asset.name, "mandatory_labels": mandatory_labels}
      }
      
-     resource_is_to_scan(asset) {
+     resource_is_to_scan(asset, resource_types_to_scan) {
      	resource_types_to_scan[_] == asset.asset_type
      }
      
@@ -98,7 +102,6 @@ spec:
      # placeholder function: in case we run into non-standard location for labels
      
      get_label(asset) = resource {
-     	resource_types_to_scan[_] == asset.asset_type
      	resource := get_generic_label(asset)
      }
      #ENDINLINE

--- a/policies/templates/gcp_enforce_labels_v1.yaml
+++ b/policies/templates/gcp_enforce_labels_v1.yaml
@@ -44,11 +44,6 @@ spec:
      # limitations under the License.
      #
      
-     # Note: supported resource types for this rule: 
-     # - projects
-     # - buckets
-     # - k8s pods
-     
      package templates.gcp.GCPResourceLabelsV1
      
      import data.validator.gcp.lib as lib

--- a/policies/templates/gcp_enforce_labels_v1.yaml
+++ b/policies/templates/gcp_enforce_labels_v1.yaml
@@ -45,87 +45,87 @@ spec:
   targets:
     validation.gcp.forsetisecurity.org:
       rego: | #INLINE("validator/enforce_labels.rego")
-     #
-     # Copyright 2018 Google LLC
-     #
-     # Licensed under the Apache License, Version 2.0 (the "License");
-     # you may not use this file except in compliance with the License.
-     # You may obtain a copy of the License at
-     #
-     #      http://www.apache.org/licenses/LICENSE-2.0
-     #
-     # Unless required by applicable law or agreed to in writing, software
-     # distributed under the License is distributed on an "AS IS" BASIS,
-     # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     # See the License for the specific language governing permissions and
-     # limitations under the License.
-     #
-     
-     package templates.gcp.GCPResourceLabelsV1
-     
-     import data.validator.gcp.lib as lib
-     
-     deny[{
-     	"msg": message,
-     	"details": metadata,
-     }] {
-     	constraint := input.constraint
-     	lib.get_constraint_params(constraint, params)
-     	asset := input.asset
-     
-     	mandatory_label := params.mandatory_labels[_]
-     	label_value_pattern := mandatory_label[label_key]
-     
-     	tested_resource_types := [
-     		"cloudresourcemanager.googleapis.com/Project",
-     		"storage.googleapis.com/Bucket",
-     		"compute.googleapis.com/Instance",
-     		"compute.googleapis.com/Image",
-     		"compute.googleapis.com/Disk",
-     		"compute.googleapis.com/Snapshot",
-     		"google.bigtable.Instance",
-     		"sqladmin.googleapis.com/Instance",
-     	]
-     
-     	non_standard_types := ["sqladmin.googleapis.com/Instance"]
-     
-     	resource_types_to_scan := lib.get_default(params, "resource_types_to_scan", tested_resource_types)
-     
-     	resource_is_to_scan(asset, resource_types_to_scan)
-     
-     	not label_is_valid(label_key, label_value_pattern, asset, non_standard_types)
-     
-     	message := sprintf("%v's label is in violation.", [asset.name])
-     	metadata := {"resource": asset.name, "label_in_violation": label_key}
-     }
-     
-     resource_is_to_scan(asset, resource_types_to_scan) {
-     	resource_types_to_scan[_] == asset.asset_type
-     }
-     
-     # check if label exists for all resources to scan
-     label_is_valid(label_key, label_value_pattern, asset, non_standard_types) {
-     	# retrieve the right values from asset
-     	resource_labels := get_labels(asset, non_standard_types)
-     
-     	# test if label exists in asset
-     	resource_labels[label_key]
-     
-     	# test if label value matches pattern passed as a parameter 
-     re_match(	label_value_pattern, resource_labels[label_key])
-     }
-     
-     # get_labels for standard resources
-     get_labels(asset, non_standard_types) = resource_labels {
-     	asset.asset_type != non_standard_types[_]
-     	resource := asset.resource.data
-     	resource_labels := lib.get_default(resource, "labels", {})
-     }
-     
-     # ge_labels for cloudsql instances
-     get_labels(asset, non_standard_types) = resource_labels {
-     	asset.asset_type == "sqladmin.googleapis.com/Instance"
-     	resource := asset.resource.data.settings
-     	resource_labels := lib.get_default(resource, "userLabels", {})
-     }
-     #ENDINLINE
+       #
+       # Copyright 2018 Google LLC
+       #
+       # Licensed under the Apache License, Version 2.0 (the "License");
+       # you may not use this file except in compliance with the License.
+       # You may obtain a copy of the License at
+       #
+       #      http://www.apache.org/licenses/LICENSE-2.0
+       #
+       # Unless required by applicable law or agreed to in writing, software
+       # distributed under the License is distributed on an "AS IS" BASIS,
+       # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       # See the License for the specific language governing permissions and
+       # limitations under the License.
+       #
+       
+       package templates.gcp.GCPEnforceLabelConstraintV1
+       
+       import data.validator.gcp.lib as lib
+       
+       deny[{
+       	"msg": message,
+       	"details": metadata,
+       }] {
+       	constraint := input.constraint
+       	lib.get_constraint_params(constraint, params)
+       	asset := input.asset
+       
+       	mandatory_label := params.mandatory_labels[_]
+       	label_value_pattern := mandatory_label[label_key]
+       
+       	tested_resource_types := [
+       		"cloudresourcemanager.googleapis.com/Project",
+       		"storage.googleapis.com/Bucket",
+       		"compute.googleapis.com/Instance",
+       		"compute.googleapis.com/Image",
+       		"compute.googleapis.com/Disk",
+       		"compute.googleapis.com/Snapshot",
+       		"google.bigtable.Instance",
+       		"sqladmin.googleapis.com/Instance",
+       	]
+       
+       	non_standard_types := ["sqladmin.googleapis.com/Instance"]
+       
+       	resource_types_to_scan := lib.get_default(params, "resource_types_to_scan", tested_resource_types)
+       
+       	resource_is_to_scan(asset, resource_types_to_scan)
+       
+       	not label_is_valid(label_key, label_value_pattern, asset, non_standard_types)
+       
+       	message := sprintf("%v's label is in violation.", [asset.name])
+       	metadata := {"resource": asset.name, "label_in_violation": label_key}
+       }
+       
+       resource_is_to_scan(asset, resource_types_to_scan) {
+       	resource_types_to_scan[_] == asset.asset_type
+       }
+       
+       # check if label exists for all resources to scan
+       label_is_valid(label_key, label_value_pattern, asset, non_standard_types) {
+       	# retrieve the right values from asset
+       	resource_labels := get_labels(asset, non_standard_types)
+       
+       	# test if label exists in asset
+       	resource_labels[label_key]
+       
+       	# test if label value matches pattern passed as a parameter 
+       re_match(	label_value_pattern, resource_labels[label_key])
+       }
+       
+       # get_labels for standard resources
+       get_labels(asset, non_standard_types) = resource_labels {
+       	asset.asset_type != non_standard_types[_]
+       	resource := asset.resource.data
+       	resource_labels := lib.get_default(resource, "labels", {})
+       }
+       
+       # ge_labels for cloudsql instances
+       get_labels(asset, non_standard_types) = resource_labels {
+       	asset.asset_type == "sqladmin.googleapis.com/Instance"
+       	resource := asset.resource.data.settings
+       	resource_labels := lib.get_default(resource, "userLabels", {})
+       }
+       #ENDINLINE

--- a/policies/templates/gcp_enforce_labels_v1.yaml
+++ b/policies/templates/gcp_enforce_labels_v1.yaml
@@ -35,7 +35,6 @@ spec:
                 "
               type: array
               items: objects
-              required: true
             resource_types_to_scan:
               description: | 
                 "Optional parameter: list of resource types to scan for labels.
@@ -53,7 +52,7 @@ spec:
                 "
               type: array
               items: string
-              required: false
+            required: ["mandatory_labels"]
   targets:
     validation.gcp.forsetisecurity.org:
       rego: | #INLINE("validator/enforce_labels.rego")

--- a/policies/templates/gcp_enforce_labels_v1.yaml
+++ b/policies/templates/gcp_enforce_labels_v1.yaml
@@ -26,9 +26,22 @@ spec:
         openAPIV3Schema:
           properties: 
             mandatory_labels:
-              description: "List of mandatory labels to check for on all supported resources. Each missing label will result in a violation."
-                type: array
-                items: string
+              description: | 
+                "List of mandatory label objects to check for on all supported resources. 
+                Label objects should be as follow:
+                label_key: label_value_regex_to_match 
+                Each missing label will result in a violation for scanned resources.
+                Each mismatching label will result in a violation for scanned resources.
+                "
+              type: array
+              items: objects
+            resource_types_to_scan:
+              description: | 
+                "Optional parameter: list of resource types to scan for labels.
+                Any resource that is not of these types will not raise any violation.
+                if not passed, all tested resource types will be scanned for violations (see below for full list)"
+              type: array
+              items: string
   targets:
     validation.gcp.forsetisecurity.org:
       rego: | #INLINE("validator/enforce_labels.rego")
@@ -60,7 +73,8 @@ spec:
      	lib.get_constraint_params(constraint, params)
      	asset := input.asset
      
-     	mandatory_labels := params.mandatory_labels[_]
+     	mandatory_label := params.mandatory_labels[_]
+     	label_value_pattern := mandatory_label[label_key]
      
      	tested_resource_types := [
      		"cloudresourcemanager.googleapis.com/Project",
@@ -70,38 +84,48 @@ spec:
      		"compute.googleapis.com/Disk",
      		"compute.googleapis.com/Snapshot",
      		"google.bigtable.Instance",
+     		"sqladmin.googleapis.com/Instance",
      	]
+     
+     	non_standard_types := ["sqladmin.googleapis.com/Instance"]
      
      	resource_types_to_scan := lib.get_default(params, "resource_types_to_scan", tested_resource_types)
      
      	resource_is_to_scan(asset, resource_types_to_scan)
-     	not label_is_valid(mandatory_labels, asset)
      
-     	message := sprintf("%v doesn't have a required label.", [asset.name])
+     	not label_is_valid(label_key, label_value_pattern, asset, non_standard_types)
      
-     	metadata := {"resource": asset.name, "mandatory_labels": mandatory_labels}
+     	message := sprintf("%v's label is in violation.", [asset.name])
+     	metadata := {"resource": asset.name, "label_in_violation": label_key}
      }
      
      resource_is_to_scan(asset, resource_types_to_scan) {
      	resource_types_to_scan[_] == asset.asset_type
      }
      
-     # generic label_is_valid for all resources
-     label_is_valid(label, asset) {
-     	resource := get_label(asset)
-     	resource_labels := lib.get_default(resource, "labels", {})
-     	labelValue := resource_labels[label]
+     # check if label exists for all resources to scan
+     label_is_valid(label_key, label_value_pattern, asset, non_standard_types) {
+     	# retrieve the right values from asset
+     	resource_labels := get_labels(asset, non_standard_types)
+     
+     	# test if label exists in asset
+     	resource_labels[label_key]
+     
+     	# test if label value matches pattern passed as a parameter 
+     re_match(	label_value_pattern, resource_labels[label_key])
      }
      
-     # get_generic_label Object for standard resources
-     get_generic_label(asset) = resource {
+     # get_labels for standard resources
+     get_labels(asset, non_standard_types) = resource_labels {
+     	asset.asset_type != non_standard_types[_]
      	resource := asset.resource.data
+     	resource_labels := lib.get_default(resource, "labels", {})
      }
      
-     # get_label for standard resources
-     # placeholder function: in case we run into non-standard location for labels
-     
-     get_label(asset) = resource {
-     	resource := get_generic_label(asset)
+     # ge_labels for cloudsql instances
+     get_labels(asset, non_standard_types) = resource_labels {
+     	asset.asset_type == "sqladmin.googleapis.com/Instance"
+     	resource := asset.resource.data.settings
+     	resource_labels := lib.get_default(resource, "userLabels", {})
      }
      #ENDINLINE

--- a/policies/templates/gcp_enforce_labels_v1.yaml
+++ b/policies/templates/gcp_enforce_labels_v1.yaml
@@ -24,7 +24,11 @@ spec:
         plural: gcpenforcelabelconstraintsv1
       validation:
         openAPIV3Schema:
-          properties: {}
+          properties: 
+            mandatory_labels:
+              description: "List of mandatory labels to check for on all supported resources. Each missing label will result in a violation."
+                type: array
+                items: string
   targets:
     validation.gcp.forsetisecurity.org:
       rego: | #INLINE("validator/enforce_labels.rego")

--- a/samples/enforce_label.yaml
+++ b/samples/enforce_label.yaml
@@ -22,11 +22,30 @@ spec:
     gcp:
       target: ["organization/*"]
   parameters: 
-    # required parameter: list of labels that need to exist to validate resource
-    # any missing label results in a violation. For instance if a resource has no label 
-    # with this sample case, it will raise 2 violations: 
-    # one for label1 being absent and one for label2.
+    # required parameter: list of label objects that resources should have.
+    # A label object is composed of a key value pair like: 
+    #
+    #   "label_key": "label_value_regex_to_match"
+    #
+    # Any missing label results in a violation. For instance a resource with no label1 or label2 label,
+    # in this sample case, would raise 2 violations: one for label1 being absent and one for label2.
+    #
+    # In the same spirit, a resource with label1 or label2 present, but with values not matching their respective regex
+    # would also raise one violation per mismatch. 
+    #
+    # In the following example, valid values for a label named "label1" would be only "label1-value",
+    # but a label named label2 could have various values like "label2-value", "label2-valueOK" etc. 
+    #
+    # A violation is raised if the label value does not match the pattern passed as a parameter here.
     mandatory_labels: 
-      - "label1"
-      - "label2"
+      - "label1": "^label1-value$"
+      - "label2": "^label2-value.*$"
+
+    # optional parameter: list of resource types to scan for labels
+    # any resource that is not of these types will not raise any violation.
+    # In this sample use case, only non-compliant projects and buckets would be flagged.
+    # If not passed, all tested resource types would be scanned for (see template for full list)
+    resource_types_to_scan:
+      - "cloudresourcemanager.googleapis.com/Project"
+      - "storage.googleapis.com/Bucket"
   

--- a/samples/enforce_label.yaml
+++ b/samples/enforce_label.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPGCPResourceLabelsV1ConstraintV1
+kind: GCPEnforceLabelConstraintV1
 metadata:
   name: require_labels
 spec:

--- a/validator/enforce_labels.rego
+++ b/validator/enforce_labels.rego
@@ -75,7 +75,7 @@ get_labels(asset, non_standard_types) = resource_labels {
 	resource_labels := lib.get_default(resource, "labels", {})
 }
 
-# ge_labels for cloudsql instances
+# get_labels for cloudsql instances
 get_labels(asset, non_standard_types) = resource_labels {
 	asset.asset_type == "sqladmin.googleapis.com/Instance"
 	resource := asset.resource.data.settings

--- a/validator/enforce_labels.rego
+++ b/validator/enforce_labels.rego
@@ -52,7 +52,8 @@ deny[{
 
 	resource_types_to_scan := lib.get_default(params, "resource_types_to_scan", tested_resource_types)
 
-	resource_is_to_scan(asset, resource_types_to_scan)
+	# test if resource needs to be scanned
+	resource_types_to_scan[_] == asset.asset_type
 
 	not label_is_valid(label_key, label_value_pattern, asset, standard_types)
 
@@ -60,11 +61,7 @@ deny[{
 	metadata := {"resource": asset.name, "label_in_violation": label_key}
 }
 
-resource_is_to_scan(asset, resource_types_to_scan) {
-	resource_types_to_scan[_] == asset.asset_type
-}
-
-# check if label exists for all resources to scan
+# check if label exists and if its value matches the pattern passed as a parameter for all resources to scan
 label_is_valid(label_key, label_value_pattern, asset, standard_types) {
 	# retrieve the right values from asset
 	resource_labels := get_labels(asset, standard_types)

--- a/validator/enforce_labels.rego
+++ b/validator/enforce_labels.rego
@@ -40,13 +40,21 @@ deny[{
 		"sqladmin.googleapis.com/Instance",
 	]
 
-	non_standard_types := ["sqladmin.googleapis.com/Instance"]
+	standard_types := [
+		"cloudresourcemanager.googleapis.com/Project",
+		"storage.googleapis.com/Bucket",
+		"compute.googleapis.com/Instance",
+		"compute.googleapis.com/Image",
+		"compute.googleapis.com/Disk",
+		"compute.googleapis.com/Snapshot",
+		"google.bigtable.Instance",
+	]
 
 	resource_types_to_scan := lib.get_default(params, "resource_types_to_scan", tested_resource_types)
 
 	resource_is_to_scan(asset, resource_types_to_scan)
 
-	not label_is_valid(label_key, label_value_pattern, asset, non_standard_types)
+	not label_is_valid(label_key, label_value_pattern, asset, standard_types)
 
 	message := sprintf("%v's label is in violation.", [asset.name])
 	metadata := {"resource": asset.name, "label_in_violation": label_key}
@@ -57,9 +65,9 @@ resource_is_to_scan(asset, resource_types_to_scan) {
 }
 
 # check if label exists for all resources to scan
-label_is_valid(label_key, label_value_pattern, asset, non_standard_types) {
+label_is_valid(label_key, label_value_pattern, asset, standard_types) {
 	# retrieve the right values from asset
-	resource_labels := get_labels(asset, non_standard_types)
+	resource_labels := get_labels(asset, standard_types)
 
 	# test if label exists in asset
 	resource_labels[label_key]
@@ -69,14 +77,14 @@ re_match(	label_value_pattern, resource_labels[label_key])
 }
 
 # get_labels for standard resources
-get_labels(asset, non_standard_types) = resource_labels {
-	asset.asset_type != non_standard_types[_]
+get_labels(asset, standard_types) = resource_labels {
+	asset.asset_type == standard_types[_]
 	resource := asset.resource.data
 	resource_labels := lib.get_default(resource, "labels", {})
 }
 
 # get_labels for cloudsql instances
-get_labels(asset, non_standard_types) = resource_labels {
+get_labels(asset, standard_types) = resource_labels {
 	asset.asset_type == "sqladmin.googleapis.com/Instance"
 	resource := asset.resource.data.settings
 	resource_labels := lib.get_default(resource, "userLabels", {})

--- a/validator/enforce_labels.rego
+++ b/validator/enforce_labels.rego
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-package templates.gcp.GCPResourceLabelsV1
+package templates.gcp.GCPEnforceLabelConstraintV1
 
 import data.validator.gcp.lib as lib
 

--- a/validator/enforce_labels.rego
+++ b/validator/enforce_labels.rego
@@ -26,7 +26,8 @@ deny[{
 	lib.get_constraint_params(constraint, params)
 	asset := input.asset
 
-	mandatory_labels := params.mandatory_labels[_]
+	mandatory_label := params.mandatory_labels[_]
+	label_value_pattern := mandatory_label[label_key]
 
 	tested_resource_types := [
 		"cloudresourcemanager.googleapis.com/Project",
@@ -36,37 +37,47 @@ deny[{
 		"compute.googleapis.com/Disk",
 		"compute.googleapis.com/Snapshot",
 		"google.bigtable.Instance",
+		"sqladmin.googleapis.com/Instance",
 	]
+
+	non_standard_types := ["sqladmin.googleapis.com/Instance"]
 
 	resource_types_to_scan := lib.get_default(params, "resource_types_to_scan", tested_resource_types)
 
 	resource_is_to_scan(asset, resource_types_to_scan)
-	not label_is_valid(mandatory_labels, asset)
 
-	message := sprintf("%v doesn't have a required label.", [asset.name])
+	not label_is_valid(label_key, label_value_pattern, asset, non_standard_types)
 
-	metadata := {"resource": asset.name, "mandatory_labels": mandatory_labels}
+	message := sprintf("%v's label is in violation.", [asset.name])
+	metadata := {"resource": asset.name, "label_in_violation": label_key}
 }
 
 resource_is_to_scan(asset, resource_types_to_scan) {
 	resource_types_to_scan[_] == asset.asset_type
 }
 
-# generic label_is_valid for all resources
-label_is_valid(label, asset) {
-	resource := get_label(asset)
-	resource_labels := lib.get_default(resource, "labels", {})
-	labelValue := resource_labels[label]
+# check if label exists for all resources to scan
+label_is_valid(label_key, label_value_pattern, asset, non_standard_types) {
+	# retrieve the right values from asset
+	resource_labels := get_labels(asset, non_standard_types)
+
+	# test if label exists in asset
+	resource_labels[label_key]
+
+	# test if label value matches pattern passed as a parameter 
+re_match(	label_value_pattern, resource_labels[label_key])
 }
 
-# get_generic_label Object for standard resources
-get_generic_label(asset) = resource {
+# get_labels for standard resources
+get_labels(asset, non_standard_types) = resource_labels {
+	asset.asset_type != non_standard_types[_]
 	resource := asset.resource.data
+	resource_labels := lib.get_default(resource, "labels", {})
 }
 
-# get_label for standard resources
-# placeholder function: in case we run into non-standard location for labels
-
-get_label(asset) = resource {
-	resource := get_generic_label(asset)
+# ge_labels for cloudsql instances
+get_labels(asset, non_standard_types) = resource_labels {
+	asset.asset_type == "sqladmin.googleapis.com/Instance"
+	resource := asset.resource.data.settings
+	resource_labels := lib.get_default(resource, "userLabels", {})
 }

--- a/validator/enforce_labels.rego
+++ b/validator/enforce_labels.rego
@@ -14,11 +14,6 @@
 # limitations under the License.
 #
 
-# Note: supported resource types for this rule: 
-# - projects
-# - buckets
-# - k8s pods
-
 package templates.gcp.GCPResourceLabelsV1
 
 import data.validator.gcp.lib as lib

--- a/validator/enforce_labels_test.rego
+++ b/validator/enforce_labels_test.rego
@@ -21,6 +21,7 @@ import data.validator.gcp.lib as lib
 # Importing the test data 
 import data.test.fixtures.enforce_labels.assets.bigtable as fixture_bigtable
 import data.test.fixtures.enforce_labels.assets.buckets as fixture_buckets
+import data.test.fixtures.enforce_labels.assets.cloudsql as fixture_cloudsql
 import data.test.fixtures.enforce_labels.assets.compute.disks as fixture_compute_disks
 import data.test.fixtures.enforce_labels.assets.compute.images as fixture_compute_images
 import data.test.fixtures.enforce_labels.assets.compute.instances as fixture_compute_instances
@@ -95,142 +96,177 @@ bigtable_violations[violation] {
 	violation := violations[_]
 }
 
+cloudsql_violations[violation] {
+	constraints := [fixture_constraints.require_labels]
+	violations := find_all_violations with data.resources as fixture_cloudsql
+		 with data.test_constraints as constraints
+
+	violation := violations[_]
+}
+
 ##### Testing for projects
 
-# Confirm four violations were found for all projects
-# 3 projects have violations - 1 of which has 2 violations (missing 2 labels) 
-test_enforce_label_projects_violates_four {
+# Confirm six violations were found for all projects
+# 4 projects have violations - 2 of which have 2 violations (one has 2 labels missing, the other has 2 labels with invalid values) 
+test_enforce_label_projects_violates_six {
 	violations := project_violations
-	count(violations) == 4
+	count(violations) == 6
 	violation := violations[_]
 	is_string(violation.msg)
 	is_object(violation.details)
 }
 
-# confirm which 3 projects are in violation
+# confirm which 4 projects are in violation
 test_enforce_label_projects_violates_basic {
 	violations := project_violations
 	violations[_].details.resource == "//cloudresourcemanager.googleapis.com/projects/169463810970"
 	violations[_].details.resource == "//cloudresourcemanager.googleapis.com/projects/357960133769"
 	violations[_].details.resource == "//cloudresourcemanager.googleapis.com/projects/357960133899"
+	violations[_].details.resource == "//cloudresourcemanager.googleapis.com/projects/357960133233"
 }
 
 ##### Testing for buckets
 
-# Confirm exactly 4 bucket violations were found
-# 3 buckets have violations - 1 of which has 2 violations (missing 2 labels)
-test_enforce_label_bucket_violates_four {
+# Confirm exactly 6 bucket violations were found
+# 4 buckets have violations - 2 of which have 2 violations (one has 2 labels missing, the other has 2 labels with invalid values)
+test_enforce_label_bucket_violates_six {
 	violations := bucket_violations
-	count(violations) == 4
+	count(violations) == 6
 	violation := violations[_]
 	is_string(violation.msg)
 	is_object(violation.details)
 }
 
-# confirm which 3 buckets are in violation
+# confirm which 4 buckets are in violation
 test_enforce_label_bucket_violates_basic {
 	violations := bucket_violations
 	violations[_].details.resource == "//storage.googleapis.com/bucket-with-no-labels"
 	violations[_].details.resource == "//storage.googleapis.com/bucket-with-label2-missing"
 	violations[_].details.resource == "//storage.googleapis.com/bucket-with-label1-missing"
+	violations[_].details.resource == "//storage.googleapis.com/bucket-with-label1-and-label2-bad-values"
 }
 
-#### Testing for GCE resources
+# #### Testing for GCE resources
 
 #### Testing for GCE instances
-# Confirm exactly 4 instance violations were found
-# 3 instances have violations - 1 of which has 2 violations (missing 2 labels)
-test_enforce_label_compute_instance_violates_four {
+# Confirm exactly 6 instance violations were found
+# 4 instances have violations - 2 of which have 2 violations (one has 2 labels missing, the other has 2 labels with invalid values)
+test_enforce_label_compute_instance_violates_six {
 	violations := compute_instance_violations
-	count(violations) == 4
+	count(violations) == 6
 	violation := violations[_]
 	is_string(violation.msg)
 	is_object(violation.details)
 }
 
-# confirm which 3 instances are in violation
+# confirm which 4 instances are in violation
 test_enforce_label_compute_instance_violates_basic {
 	violations := compute_instance_violations
 	violations[_].details.resource == "//compute.googleapis.com/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/instances/invalid-instance-missing-labels-8hz5"
 	violations[_].details.resource == "//compute.googleapis.com/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/instances/invalid-instance-missing-label1-8hz5"
 	violations[_].details.resource == "//compute.googleapis.com/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/instances/invalid-instance-missing-label2-8hz5"
+	violations[_].details.resource == "//compute.googleapis.com/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/instances/invalid-instance-with-label1-and-label2-bad-values"
 }
 
 #### Testing for GCE Images
 # Confirm exactly 4 images violations were found
-# 3 images have violations - 1 of which has 2 violations (missing 2 labels)
-test_enforce_label_compute_instance_violates_four {
+# 4 images have violations - 2 of which have 2 violations (one has 2 labels missing, the other has 2 labels with invalid values)
+test_enforce_label_compute_instance_violates_six {
 	violations := compute_image_violations
-	count(violations) == 4
+	count(violations) == 6
 	violation := violations[_]
 	is_string(violation.msg)
 	is_object(violation.details)
 }
 
-# confirm which 3 images are in violation
+# confirm which 4 images are in violation
 test_enforce_label_compute_image_violates_basic {
 	violations := compute_image_violations
 	violations[_].details.resource == "//compute.googleapis.com/projects/my-own-project/global/images/test-invalid-image-missing-label1"
 	violations[_].details.resource == "//compute.googleapis.com/projects/my-own-project/global/images/test-invalid-image-missing-label2"
 	violations[_].details.resource == "//compute.googleapis.com/projects/my-own-project/global/images/test-invalid-image-missing-label1"
+	violations[_].details.resource == "//compute.googleapis.com/projects/my-own-project/global/images/test-invalid-image-label1-and-label2-bad-values"
 }
 
 #### Testing for GCE Disks
-# Confirm exactly 4 disk violations were found
-# 3 disks have violations - 1 of which has 2 violations (missing 2 labels)
-test_enforce_label_compute_disk_violates_four {
+# Confirm exactly 6 disk violations were found
+# 4 disks have violations - 2 of which have 2 violations (one has 2 labels missing, the other has 2 labels with invalid values)
+test_enforce_label_compute_disk_violates_six {
 	violations := compute_disk_violations
-	count(violations) == 4
+	count(violations) == 6
 	violation := violations[_]
 	is_string(violation.msg)
 	is_object(violation.details)
 }
 
-# confirm which 3 disks are in violation
+# confirm which 4 disks are in violation
 test_enforce_label_compute_disk_violates_basic {
 	violations := compute_disk_violations
 
 	violations[_].details.resource == "//compute.googleapis.com/projects/my-test-project/zones/us-east1-b/disks/instance-1-invalid-disk-missing-labels"
 	violations[_].details.resource == "//compute.googleapis.com/projects/my-test-project/zones/us-east1-b/disks/instance-1-invalid-disk-missing-label1"
 	violations[_].details.resource == "//compute.googleapis.com/projects/my-test-project/zones/us-east1-b/disks/instance-1-invalid-disk-missing-label2"
+	violations[_].details.resource == "//compute.googleapis.com/projects/my-test-project/zones/us-east1-b/disks/instance-1-invalid-disk-label1-and-label2-bad-values"
 }
 
 #### Testing for GCE Snapshots
-# Confirm exactly 4 snapshot violations were found
-# 3 snapshots have violations - 1 of which has 2 violations (missing 2 labels)
-test_enforce_label_compute_snapshot_violates_four {
+# Confirm exactly 6 snapshot violations were found
+# 4 snapshots have violations - 2 of which have 2 violations (one has 2 labels missing, the other has 2 labels with invalid values)
+test_enforce_label_compute_snapshot_violates_six {
 	violations := compute_snapshot_violations
-	count(violations) == 4
+	count(violations) == 6
 	violation := violations[_]
 	is_string(violation.msg)
 	is_object(violation.details)
 }
 
-# confirm which 3 snapshots are in violation
+# confirm which 4 snapshots are in violation
 test_enforce_label_compute_snapshot_violates_basic {
 	violations := compute_snapshot_violations
 
 	violations[_].details.resource == "//compute.googleapis.com/projects/my-test-project/global/snapshots/snapshot-1-invalid-missing-labels"
 	violations[_].details.resource == "//compute.googleapis.com/projects/my-test-project/global/snapshots/snapshot-1-invalid-missing-label1"
 	violations[_].details.resource == "//compute.googleapis.com/projects/my-test-project/global/snapshots/snapshot-1-invalid-missing-label2"
+	violations[_].details.resource == "//compute.googleapis.com/projects/my-test-project/global/snapshots/snapshot-1-invalid-label1-and-label2-bad-values"
 }
 
 #### Testing for BigTable Instances
-# Confirm exactly 4 bigtable violations were found
-# 3 bigtable instances have violations - 1 of which has 2 violations (missing 2 labels)
-test_enforce_label_bigtable_violates_four {
+# Confirm exactly 6 bigtable violations were found
+# 4 bigtable instances have violations - 2 of which have 2 violations (one has 2 labels missing, the other has 2 labels with invalid values)
+test_enforce_label_bigtable_violates_six {
 	violations := bigtable_violations
-	count(violations) == 4
+	count(violations) == 6
 	violation := violations[_]
 	is_string(violation.msg)
 	is_object(violation.details)
 }
 
-# confirm which 3 bigtable instances are in violation
+# confirm which 4 bigtable instances are in violation
 test_enforce_label_bigtable_violates_basic {
 	violations := bigtable_violations
 
 	violations[_].details.resource == "//bigtable.googleapis.com/projects/my-test-project/instances/test-bigtable-invalid-missing-labels"
 	violations[_].details.resource == "//bigtable.googleapis.com/projects/my-test-project/instances/test-bigtable-invalid-missing-label1"
 	violations[_].details.resource == "//bigtable.googleapis.com/projects/my-test-project/instances/test-bigtable-invalid-missing-label2"
+	violations[_].details.resource == "//bigtable.googleapis.com/projects/my-test-project/instances/test-bigtable-invalid-label1-and-label2-bad-values"
+}
+
+#### Testing for CloudSQL Instances
+# Confirm exactly 6 cloudsql violations were found
+# 4 cloudsql instances have violations - 2 of which have 2 violations (one has 2 labels missing, the other has 2 labels with invalid values)
+test_enforce_label_cloudsql_violates_six {
+	violations := cloudsql_violations
+	count(violations) == 6
+	violation := violations[_]
+	is_string(violation.msg)
+	is_object(violation.details)
+}
+
+# confirm which 4 cloudsql instances are in violation
+test_enforce_label_cloudsql_violates_basic {
+	violations := cloudsql_violations
+	violations[_].details.resource == "//cloudsql.googleapis.com/projects/my-test-project/instances/cloudsql-instance-1-invalid-missing-labels"
+	violations[_].details.resource == "//cloudsql.googleapis.com/projects/my-test-project/instances/cloudsql-instance-1-invalid-missing-label1"
+	violations[_].details.resource == "//cloudsql.googleapis.com/projects/my-test-project/instances/cloudsql-instance-1-invalid-missing-label2"
+	violations[_].details.resource == "//cloudsql.googleapis.com/projects/my-test-project/instances/cloudsql-instance-1-invalid-label1-and-label2-bad-values"
 }

--- a/validator/enforce_labels_test.rego
+++ b/validator/enforce_labels_test.rego
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-package templates.gcp.GCPResourceLabelsV1
+package templates.gcp.GCPEnforceLabelConstraintV1
 
 import data.validator.gcp.lib as lib
 

--- a/validator/enforce_labels_test.rego
+++ b/validator/enforce_labels_test.rego
@@ -107,166 +107,194 @@ cloudsql_violations[violation] {
 ##### Testing for projects
 
 # Confirm six violations were found for all projects
-# 4 projects have violations - 2 of which have 2 violations (one has 2 labels missing, the other has 2 labels with invalid values) 
-test_enforce_label_projects_violates_six {
+# 4 projects have violations - 2 of which have 2 violations (one has 2 labels missing, 
+# the other has 2 labels with invalid values) 
+# confirm which 4 projects are in violation
+test_enforce_label_projects_violations {
 	violations := project_violations
 	count(violations) == 6
+
+	resource_names := {x | x = violations[_].details.resource}
+	expected_resource_name := {
+		"//cloudresourcemanager.googleapis.com/projects/169463810970",
+		"//cloudresourcemanager.googleapis.com/projects/357960133769",
+		"//cloudresourcemanager.googleapis.com/projects/357960133899",
+		"//cloudresourcemanager.googleapis.com/projects/357960133233",
+	}
+
+	resource_names == expected_resource_name
+
 	violation := violations[_]
 	is_string(violation.msg)
 	is_object(violation.details)
-}
-
-# confirm which 4 projects are in violation
-test_enforce_label_projects_violates_basic {
-	violations := project_violations
-	violations[_].details.resource == "//cloudresourcemanager.googleapis.com/projects/169463810970"
-	violations[_].details.resource == "//cloudresourcemanager.googleapis.com/projects/357960133769"
-	violations[_].details.resource == "//cloudresourcemanager.googleapis.com/projects/357960133899"
-	violations[_].details.resource == "//cloudresourcemanager.googleapis.com/projects/357960133233"
 }
 
 ##### Testing for buckets
 
 # Confirm exactly 6 bucket violations were found
-# 4 buckets have violations - 2 of which have 2 violations (one has 2 labels missing, the other has 2 labels with invalid values)
-test_enforce_label_bucket_violates_six {
+# 4 buckets have violations - 2 of which have 2 violations (one has 2 labels missing,
+# the other has 2 labels with invalid values)
+# confirm which 4 buckets are in violation
+test_enforce_label_bucket_violations {
 	violations := bucket_violations
+
 	count(violations) == 6
+
+	resource_names := {x | x = violations[_].details.resource}
+	expected_resource_name := {
+		"//storage.googleapis.com/bucket-with-no-labels",
+		"//storage.googleapis.com/bucket-with-label2-missing",
+		"//storage.googleapis.com/bucket-with-label1-missing",
+		"//storage.googleapis.com/bucket-with-label1-and-label2-bad-values",
+	}
+
+	resource_names == expected_resource_name
+
 	violation := violations[_]
 	is_string(violation.msg)
 	is_object(violation.details)
 }
 
-# confirm which 4 buckets are in violation
-test_enforce_label_bucket_violates_basic {
-	violations := bucket_violations
-	violations[_].details.resource == "//storage.googleapis.com/bucket-with-no-labels"
-	violations[_].details.resource == "//storage.googleapis.com/bucket-with-label2-missing"
-	violations[_].details.resource == "//storage.googleapis.com/bucket-with-label1-missing"
-	violations[_].details.resource == "//storage.googleapis.com/bucket-with-label1-and-label2-bad-values"
-}
-
-# #### Testing for GCE resources
+##### Testing for GCE resources
 
 #### Testing for GCE instances
+
 # Confirm exactly 6 instance violations were found
 # 4 instances have violations - 2 of which have 2 violations (one has 2 labels missing, the other has 2 labels with invalid values)
-test_enforce_label_compute_instance_violates_six {
+# confirm which 4 instances are in violation
+test_enforce_label_compute_instance_violations {
 	violations := compute_instance_violations
 	count(violations) == 6
+
+	resource_names := {x | x = violations[_].details.resource}
+	expected_resource_name := {
+		"//compute.googleapis.com/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/instances/invalid-instance-missing-labels-8hz5",
+		"//compute.googleapis.com/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/instances/invalid-instance-missing-label1-8hz5",
+		"//compute.googleapis.com/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/instances/invalid-instance-missing-label2-8hz5",
+		"//compute.googleapis.com/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/instances/invalid-instance-with-label1-and-label2-bad-values",
+	}
+
+	resource_names == expected_resource_name
+
 	violation := violations[_]
 	is_string(violation.msg)
 	is_object(violation.details)
-}
-
-# confirm which 4 instances are in violation
-test_enforce_label_compute_instance_violates_basic {
-	violations := compute_instance_violations
-	violations[_].details.resource == "//compute.googleapis.com/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/instances/invalid-instance-missing-labels-8hz5"
-	violations[_].details.resource == "//compute.googleapis.com/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/instances/invalid-instance-missing-label1-8hz5"
-	violations[_].details.resource == "//compute.googleapis.com/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/instances/invalid-instance-missing-label2-8hz5"
-	violations[_].details.resource == "//compute.googleapis.com/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/instances/invalid-instance-with-label1-and-label2-bad-values"
 }
 
 #### Testing for GCE Images
 # Confirm exactly 4 images violations were found
-# 4 images have violations - 2 of which have 2 violations (one has 2 labels missing, the other has 2 labels with invalid values)
-test_enforce_label_compute_instance_violates_six {
+# 4 images have violations - 2 of which have 2 violations (one has 2 labels missing,
+# the other has 2 labels with invalid values)
+# confirm which 4 images are in violation
+test_enforce_label_compute_image_violations {
 	violations := compute_image_violations
 	count(violations) == 6
+
+	resource_names := {x | x = violations[_].details.resource}
+	expected_resource_name := {
+		"//compute.googleapis.com/projects/my-own-project/global/images/test-invalid-image-missing-labels",
+		"//compute.googleapis.com/projects/my-own-project/global/images/test-invalid-image-missing-label2",
+		"//compute.googleapis.com/projects/my-own-project/global/images/test-invalid-image-missing-label1",
+		"//compute.googleapis.com/projects/my-own-project/global/images/test-invalid-image-label1-and-label2-bad-values",
+	}
+
+	resource_names == expected_resource_name
+
 	violation := violations[_]
 	is_string(violation.msg)
 	is_object(violation.details)
-}
-
-# confirm which 4 images are in violation
-test_enforce_label_compute_image_violates_basic {
-	violations := compute_image_violations
-	violations[_].details.resource == "//compute.googleapis.com/projects/my-own-project/global/images/test-invalid-image-missing-label1"
-	violations[_].details.resource == "//compute.googleapis.com/projects/my-own-project/global/images/test-invalid-image-missing-label2"
-	violations[_].details.resource == "//compute.googleapis.com/projects/my-own-project/global/images/test-invalid-image-missing-label1"
-	violations[_].details.resource == "//compute.googleapis.com/projects/my-own-project/global/images/test-invalid-image-label1-and-label2-bad-values"
 }
 
 #### Testing for GCE Disks
 # Confirm exactly 6 disk violations were found
-# 4 disks have violations - 2 of which have 2 violations (one has 2 labels missing, the other has 2 labels with invalid values)
-test_enforce_label_compute_disk_violates_six {
+# 4 disks have violations - 2 of which have 2 violations (one has 2 labels missing,
+# the other has 2 labels with invalid values)
+# confirm which 4 disks are in violation
+test_enforce_label_compute_disk_violations {
 	violations := compute_disk_violations
 	count(violations) == 6
+
+	resource_names := {x | x = violations[_].details.resource}
+	expected_resource_name := {
+		"//compute.googleapis.com/projects/my-test-project/zones/us-east1-b/disks/instance-1-invalid-disk-missing-labels",
+		"//compute.googleapis.com/projects/my-test-project/zones/us-east1-b/disks/instance-1-invalid-disk-missing-label1",
+		"//compute.googleapis.com/projects/my-test-project/zones/us-east1-b/disks/instance-1-invalid-disk-missing-label2",
+		"//compute.googleapis.com/projects/my-test-project/zones/us-east1-b/disks/instance-1-invalid-disk-label1-and-label2-bad-values",
+	}
+
+	resource_names == expected_resource_name
+
 	violation := violations[_]
 	is_string(violation.msg)
 	is_object(violation.details)
-}
-
-# confirm which 4 disks are in violation
-test_enforce_label_compute_disk_violates_basic {
-	violations := compute_disk_violations
-
-	violations[_].details.resource == "//compute.googleapis.com/projects/my-test-project/zones/us-east1-b/disks/instance-1-invalid-disk-missing-labels"
-	violations[_].details.resource == "//compute.googleapis.com/projects/my-test-project/zones/us-east1-b/disks/instance-1-invalid-disk-missing-label1"
-	violations[_].details.resource == "//compute.googleapis.com/projects/my-test-project/zones/us-east1-b/disks/instance-1-invalid-disk-missing-label2"
-	violations[_].details.resource == "//compute.googleapis.com/projects/my-test-project/zones/us-east1-b/disks/instance-1-invalid-disk-label1-and-label2-bad-values"
 }
 
 #### Testing for GCE Snapshots
 # Confirm exactly 6 snapshot violations were found
-# 4 snapshots have violations - 2 of which have 2 violations (one has 2 labels missing, the other has 2 labels with invalid values)
-test_enforce_label_compute_snapshot_violates_six {
+# 4 snapshots have violations - 2 of which have 2 violations (one has 2 labels missing,
+# the other has 2 labels with invalid values)
+# confirm which 4 snapshots are in violation
+test_enforce_label_compute_snapshot_violations {
 	violations := compute_snapshot_violations
 	count(violations) == 6
+
+	resource_names := {x | x = violations[_].details.resource}
+	expected_resource_name := {
+		"//compute.googleapis.com/projects/my-test-project/global/snapshots/snapshot-1-invalid-missing-labels",
+		"//compute.googleapis.com/projects/my-test-project/global/snapshots/snapshot-1-invalid-missing-label1",
+		"//compute.googleapis.com/projects/my-test-project/global/snapshots/snapshot-1-invalid-missing-label2",
+		"//compute.googleapis.com/projects/my-test-project/global/snapshots/snapshot-1-invalid-label1-and-label2-bad-values",
+	}
+
+	resource_names == expected_resource_name
+
 	violation := violations[_]
 	is_string(violation.msg)
 	is_object(violation.details)
-}
-
-# confirm which 4 snapshots are in violation
-test_enforce_label_compute_snapshot_violates_basic {
-	violations := compute_snapshot_violations
-
-	violations[_].details.resource == "//compute.googleapis.com/projects/my-test-project/global/snapshots/snapshot-1-invalid-missing-labels"
-	violations[_].details.resource == "//compute.googleapis.com/projects/my-test-project/global/snapshots/snapshot-1-invalid-missing-label1"
-	violations[_].details.resource == "//compute.googleapis.com/projects/my-test-project/global/snapshots/snapshot-1-invalid-missing-label2"
-	violations[_].details.resource == "//compute.googleapis.com/projects/my-test-project/global/snapshots/snapshot-1-invalid-label1-and-label2-bad-values"
 }
 
 #### Testing for BigTable Instances
 # Confirm exactly 6 bigtable violations were found
 # 4 bigtable instances have violations - 2 of which have 2 violations (one has 2 labels missing, the other has 2 labels with invalid values)
-test_enforce_label_bigtable_violates_six {
+# confirm which 4 bigtable instances are in violation
+test_enforce_label_bigtable_violations {
 	violations := bigtable_violations
 	count(violations) == 6
+
+	resource_names := {x | x = violations[_].details.resource}
+	expected_resource_name := {
+		"//bigtable.googleapis.com/projects/my-test-project/instances/test-bigtable-invalid-missing-labels",
+		"//bigtable.googleapis.com/projects/my-test-project/instances/test-bigtable-invalid-missing-label1",
+		"//bigtable.googleapis.com/projects/my-test-project/instances/test-bigtable-invalid-missing-label2",
+		"//bigtable.googleapis.com/projects/my-test-project/instances/test-bigtable-invalid-label1-and-label2-bad-values",
+	}
+
+	resource_names == expected_resource_name
+
 	violation := violations[_]
 	is_string(violation.msg)
 	is_object(violation.details)
-}
-
-# confirm which 4 bigtable instances are in violation
-test_enforce_label_bigtable_violates_basic {
-	violations := bigtable_violations
-
-	violations[_].details.resource == "//bigtable.googleapis.com/projects/my-test-project/instances/test-bigtable-invalid-missing-labels"
-	violations[_].details.resource == "//bigtable.googleapis.com/projects/my-test-project/instances/test-bigtable-invalid-missing-label1"
-	violations[_].details.resource == "//bigtable.googleapis.com/projects/my-test-project/instances/test-bigtable-invalid-missing-label2"
-	violations[_].details.resource == "//bigtable.googleapis.com/projects/my-test-project/instances/test-bigtable-invalid-label1-and-label2-bad-values"
 }
 
 #### Testing for CloudSQL Instances
 # Confirm exactly 6 cloudsql violations were found
 # 4 cloudsql instances have violations - 2 of which have 2 violations (one has 2 labels missing, the other has 2 labels with invalid values)
-test_enforce_label_cloudsql_violates_six {
+# confirm which 4 cloudsql instances are in violation
+test_enforce_label_cloudsql_violations {
 	violations := cloudsql_violations
 	count(violations) == 6
+
+	resource_names := {x | x = violations[_].details.resource}
+	expected_resource_name := {
+		"//cloudsql.googleapis.com/projects/my-test-project/instances/cloudsql-instance-1-invalid-missing-labels",
+		"//cloudsql.googleapis.com/projects/my-test-project/instances/cloudsql-instance-1-invalid-missing-label1",
+		"//cloudsql.googleapis.com/projects/my-test-project/instances/cloudsql-instance-1-invalid-missing-label2",
+		"//cloudsql.googleapis.com/projects/my-test-project/instances/cloudsql-instance-1-invalid-label1-and-label2-bad-values",
+	}
+
+	resource_names == expected_resource_name
+
 	violation := violations[_]
 	is_string(violation.msg)
 	is_object(violation.details)
-}
-
-# confirm which 4 cloudsql instances are in violation
-test_enforce_label_cloudsql_violates_basic {
-	violations := cloudsql_violations
-	violations[_].details.resource == "//cloudsql.googleapis.com/projects/my-test-project/instances/cloudsql-instance-1-invalid-missing-labels"
-	violations[_].details.resource == "//cloudsql.googleapis.com/projects/my-test-project/instances/cloudsql-instance-1-invalid-missing-label1"
-	violations[_].details.resource == "//cloudsql.googleapis.com/projects/my-test-project/instances/cloudsql-instance-1-invalid-missing-label2"
-	violations[_].details.resource == "//cloudsql.googleapis.com/projects/my-test-project/instances/cloudsql-instance-1-invalid-label1-and-label2-bad-values"
 }

--- a/validator/enforce_labels_test.rego
+++ b/validator/enforce_labels_test.rego
@@ -88,8 +88,9 @@ compute_snapshot_violations[violation] {
 
 ##### Testing for projects
 
-# # Confirm four violations were found for all projects
-test_enforce_label_projects_violates_project_four {
+# Confirm four violations were found for all projects
+# 3 projects have violations - 1 of which has 2 violations (missing 2 labels) 
+test_enforce_label_projects_violates_four {
 	violations := project_violations
 	count(violations) == 4
 	violation := violations[_]
@@ -98,7 +99,7 @@ test_enforce_label_projects_violates_project_four {
 }
 
 # confirm which 3 projects are in violation
-test_enforce_label_projects_violates_project_basic {
+test_enforce_label_projects_violates_basic {
 	violations := project_violations
 	violations[_].details.resource == "//cloudresourcemanager.googleapis.com/projects/169463810970"
 	violations[_].details.resource == "//cloudresourcemanager.googleapis.com/projects/357960133769"
@@ -107,8 +108,9 @@ test_enforce_label_projects_violates_project_basic {
 
 ##### Testing for buckets
 
-# # Confirm exactly 4 bucket violations were found
-test_enforce_label_bucket_violates_project_four {
+# Confirm exactly 4 bucket violations were found
+# 3 buckets have violations - 1 of which has 2 violations (missing 2 labels)
+test_enforce_label_bucket_violates_four {
 	violations := bucket_violations
 	count(violations) == 4
 	violation := violations[_]
@@ -117,7 +119,7 @@ test_enforce_label_bucket_violates_project_four {
 }
 
 # confirm which 3 buckets are in violation
-test_enforce_label_bucket_violates_project_basic {
+test_enforce_label_bucket_violates_basic {
 	violations := bucket_violations
 	violations[_].details.resource == "//storage.googleapis.com/bucket-with-no-labels"
 	violations[_].details.resource == "//storage.googleapis.com/bucket-with-label2-missing"
@@ -127,8 +129,9 @@ test_enforce_label_bucket_violates_project_basic {
 #### Testing for GCE resources
 
 #### Testing for GCE instances
-# # Confirm exactly 4 instance violations were found
-test_enforce_label_compute_instance_violates_project_four {
+# Confirm exactly 4 instance violations were found
+# 3 instances have violations - 1 of which has 2 violations (missing 2 labels)
+test_enforce_label_compute_instance_violates_four {
 	violations := compute_instance_violations
 	count(violations) == 4
 	violation := violations[_]
@@ -137,7 +140,7 @@ test_enforce_label_compute_instance_violates_project_four {
 }
 
 # confirm which 3 instances are in violation
-test_enforce_label_compute_instance_violates_project_basic {
+test_enforce_label_compute_instance_violates_basic {
 	violations := compute_instance_violations
 	violations[_].details.resource == "//compute.googleapis.com/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/instances/invalid-instance-missing-labels-8hz5"
 	violations[_].details.resource == "//compute.googleapis.com/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/instances/invalid-instance-missing-label1-8hz5"
@@ -145,8 +148,9 @@ test_enforce_label_compute_instance_violates_project_basic {
 }
 
 #### Testing for GCE Images
-# # Confirm exactly 4 images violations were found
-test_enforce_label_compute_instance_violates_project_four {
+# Confirm exactly 4 images violations were found
+# 3 images have violations - 1 of which has 2 violations (missing 2 labels)
+test_enforce_label_compute_instance_violates_four {
 	violations := compute_image_violations
 	count(violations) == 4
 	violation := violations[_]
@@ -155,7 +159,7 @@ test_enforce_label_compute_instance_violates_project_four {
 }
 
 # confirm which 3 images are in violation
-test_enforce_label_compute_image_violates_project_basic {
+test_enforce_label_compute_image_violates_basic {
 	violations := compute_image_violations
 	violations[_].details.resource == "//compute.googleapis.com/projects/my-own-project/global/images/test-invalid-image-missing-label1"
 	violations[_].details.resource == "//compute.googleapis.com/projects/my-own-project/global/images/test-invalid-image-missing-label2"
@@ -163,8 +167,9 @@ test_enforce_label_compute_image_violates_project_basic {
 }
 
 #### Testing for GCE Disks
-# # Confirm exactly 4 disk violations were found
-test_enforce_label_compute_disk_violates_project_four {
+# Confirm exactly 4 disk violations were found
+# 3 disks have violations - 1 of which has 2 violations (missing 2 labels)
+test_enforce_label_compute_disk_violates_four {
 	violations := compute_disk_violations
 	count(violations) == 4
 	violation := violations[_]
@@ -173,7 +178,7 @@ test_enforce_label_compute_disk_violates_project_four {
 }
 
 # confirm which 3 disks are in violation
-test_enforce_label_compute_disk_violates_project_basic {
+test_enforce_label_compute_disk_violates_basic {
 	violations := compute_disk_violations
 
 	violations[_].details.resource == "//compute.googleapis.com/projects/my-test-project/zones/us-east1-b/disks/instance-1-invalid-disk-missing-labels"
@@ -182,8 +187,9 @@ test_enforce_label_compute_disk_violates_project_basic {
 }
 
 #### Testing for GCE Snapshots
-# # Confirm exactly 4 snapshot violations were found
-test_enforce_label_compute_snapshot_violates_project_four {
+# Confirm exactly 4 snapshot violations were found
+# 3 snapshots have violations - 1 of which has 2 violations (missing 2 labels)
+test_enforce_label_compute_snapshot_violates_four {
 	violations := compute_snapshot_violations
 	count(violations) == 4
 	violation := violations[_]
@@ -192,7 +198,7 @@ test_enforce_label_compute_snapshot_violates_project_four {
 }
 
 # confirm which 3 snapshots are in violation
-test_enforce_label_compute_snapshot_violates_project_basic {
+test_enforce_label_compute_snapshot_violates_basic {
 	violations := compute_snapshot_violations
 
 	violations[_].details.resource == "//compute.googleapis.com/projects/my-test-project/global/snapshots/snapshot-1-invalid-missing-labels"

--- a/validator/test/fixtures/enforce_labels/assets/bigtable/data.json
+++ b/validator/test/fixtures/enforce_labels/assets/bigtable/data.json
@@ -10,7 +10,7 @@
                 "displayName": "test-bigtable-id-valid-labels",
                 "labels": {
                     "label1": "label1-value",
-                    "label2": "label2-value"
+                    "label2": "label2-valueOK"
                 },
                 "name": "projects/my-test-project/instances/test-bigtable-id-valid-labels",
                 "state": "READY",
@@ -43,7 +43,7 @@
             "data": {
                 "displayName": "test-bigtable-invalid-missing-label1",
                 "labels": {
-                    "label2": "label2-value"
+                    "label2": "label2-valueOKTOO"
                 },
                 "name": "projects/my-test-project/instances/test-bigtable-invalid-missing-label1",
                 "state": "READY",
@@ -64,6 +64,25 @@
                     "label1": "label1-value"
                 },
                 "name": "projects/my-test-project/instances/test-bigtable-invalid-missing-label2",
+                "state": "READY",
+                "type": "PRODUCTION"
+            }
+        }
+    },
+    {
+        "name": "//bigtable.googleapis.com/projects/my-test-project/instances/test-bigtable-invalid-label1-and-label2-bad-values",
+        "asset_type": "google.bigtable.Instance",
+        "resource": {
+            "version": "v2",
+            "discovery_document_uri": "https://bigtableadmin.googleapis.com/$discovery/rest",
+            "discovery_name": "Instance",
+            "data": {
+                "displayName": "test-bigtable-invalid-label1-and-label2-bad-values",
+                "labels": {
+                    "label1": "label1-bad-value",
+                    "label2": "label2-bad-value"
+                },
+                "name": "projects/my-test-project/instances/test-bigtable-invalid-label1-and-label2-bad-values",
                 "state": "READY",
                 "type": "PRODUCTION"
             }

--- a/validator/test/fixtures/enforce_labels/assets/bigtable/data.json
+++ b/validator/test/fixtures/enforce_labels/assets/bigtable/data.json
@@ -1,0 +1,72 @@
+[
+    {
+        "name": "//bigtable.googleapis.com/projects/my-test-project/instances/test-bigtable-id-valid-labels",
+        "asset_type": "google.bigtable.Instance",
+        "resource": {
+            "version": "v2",
+            "discovery_document_uri": "https://bigtableadmin.googleapis.com/$discovery/rest",
+            "discovery_name": "Instance",
+            "data": {
+                "displayName": "test-bigtable-id-valid-labels",
+                "labels": {
+                    "label1": "label1-value",
+                    "label2": "label2-value"
+                },
+                "name": "projects/my-test-project/instances/test-bigtable-id-valid-labels",
+                "state": "READY",
+                "type": "PRODUCTION"
+            }
+        }
+    },
+    {
+        "name": "//bigtable.googleapis.com/projects/my-test-project/instances/test-bigtable-invalid-missing-labels",
+        "asset_type": "google.bigtable.Instance",
+        "resource": {
+            "version": "v2",
+            "discovery_document_uri": "https://bigtableadmin.googleapis.com/$discovery/rest",
+            "discovery_name": "Instance",
+            "data": {
+                "displayName": "test-bigtable-invalid-missing-labels",
+                "name": "projects/my-test-project/instances/test-bigtable-invalid-missing-labels",
+                "state": "READY",
+                "type": "PRODUCTION"
+            }
+        }
+    },
+    {
+        "name": "//bigtable.googleapis.com/projects/my-test-project/instances/test-bigtable-invalid-missing-label1",
+        "asset_type": "google.bigtable.Instance",
+        "resource": {
+            "version": "v2",
+            "discovery_document_uri": "https://bigtableadmin.googleapis.com/$discovery/rest",
+            "discovery_name": "Instance",
+            "data": {
+                "displayName": "test-bigtable-invalid-missing-label1",
+                "labels": {
+                    "label2": "label2-value"
+                },
+                "name": "projects/my-test-project/instances/test-bigtable-invalid-missing-label1",
+                "state": "READY",
+                "type": "PRODUCTION"
+            }
+        }
+    },
+    {
+        "name": "//bigtable.googleapis.com/projects/my-test-project/instances/test-bigtable-invalid-missing-label2",
+        "asset_type": "google.bigtable.Instance",
+        "resource": {
+            "version": "v2",
+            "discovery_document_uri": "https://bigtableadmin.googleapis.com/$discovery/rest",
+            "discovery_name": "Instance",
+            "data": {
+                "displayName": "test-bigtable-invalid-missing-label2",
+                "labels": {
+                    "label1": "label1-value"
+                },
+                "name": "projects/my-test-project/instances/test-bigtable-invalid-missing-label2",
+                "state": "READY",
+                "type": "PRODUCTION"
+            }
+        }
+    }
+]

--- a/validator/test/fixtures/enforce_labels/assets/buckets/data.json
+++ b/validator/test/fixtures/enforce_labels/assets/buckets/data.json
@@ -24,8 +24,8 @@
         "kind": "storage#bucket",
         "labels": {
           "my-label-key": "some-value",
-          "label2": "some-other-vale",
-          "label1": "another-value"
+          "label2": "label2-value",
+          "label1": "label1-value"
         },
         "lifecycle": {
           "rule": []
@@ -113,7 +113,7 @@
         "kind": "storage#bucket",
         "labels": {
           "my-label-key": "some-value",
-          "label1": "some-other-vale"
+          "label1": "label1-value"
         },
         "lifecycle": {
           "rule": []
@@ -159,7 +159,7 @@
         "kind": "storage#bucket",
         "labels": {
           "my-label-key": "some-value",
-          "label2": "some-other-vale"
+          "label2": "label2-valueOK"
         },
         "lifecycle": {
           "rule": []
@@ -172,6 +172,53 @@
         "projectNumber": 318576589455,
         "retentionPolicy": {},
         "selfLink": "https://www.googleapis.com/storage/v1/b/bucket-with-label1-missing",
+        "storageClass": "REGIONAL",
+        "timeCreated": "2019-05-15T15:05:56.580Z",
+        "updated": "2019-05-15T15:56:44.899Z",
+        "versioning": {},
+        "website": {}
+      }
+    }
+  },
+  {
+    "name": "//storage.googleapis.com/bucket-with-label1-and-label2-bad-values",
+    "asset_type": "storage.googleapis.com/Bucket",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/storage/v1/rest",
+      "discovery_name": "Bucket",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/318576589455",
+      "data": {
+        "acl": [],
+        "billing": {},
+        "cors": [],
+        "defaultObjectAcl": [],
+        "encryption": {},
+        "etag": "CAU=",
+        "iamConfiguration": {
+          "bucketPolicyOnly": {
+            "enabled": true,
+            "lockedTime": "2019-08-13T15:22:00.617Z"
+          }
+        },
+        "id": "bucket-with-label1-and-label2-bad-values",
+        "kind": "storage#bucket",
+        "labels": {
+          "my-label-key": "some-value",
+          "label2": "label2-with-bad-value",
+          "label1": "label1-with-bad-value"
+        },
+        "lifecycle": {
+          "rule": []
+        },
+        "location": "US-CENTRAL1",
+        "logging": {},
+        "metageneration": 5,
+        "name": "bucket-with-label1-missing",
+        "owner": {},
+        "projectNumber": 318576589455,
+        "retentionPolicy": {},
+        "selfLink": "https://www.googleapis.com/storage/v1/b/bucket-with-label1-and-label2-bad-values",
         "storageClass": "REGIONAL",
         "timeCreated": "2019-05-15T15:05:56.580Z",
         "updated": "2019-05-15T15:56:44.899Z",

--- a/validator/test/fixtures/enforce_labels/assets/cloudsql/data.json
+++ b/validator/test/fixtures/enforce_labels/assets/cloudsql/data.json
@@ -1,0 +1,276 @@
+[
+    {
+        "name": "//cloudsql.googleapis.com/projects/my-test-project/instances/cloudsql-instance-1-valid",
+        "asset_type": "sqladmin.googleapis.com/Instance",
+        "resource": {
+            "version": "v1beta4",
+            "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/sqladmin/v1beta4/rest",
+            "discovery_name": "DatabaseInstance",
+            "data": {
+                "backendType": "SECOND_GEN",
+                "connectionName": "my-test-project:us-central1:cloudsql-instance-1-valid",
+                "databaseVersion": "MYSQL_5_7",
+                "gceZone": "us-central1-a",
+                "instanceType": "CLOUD_SQL_INSTANCE",
+                "kind": "sql#instance",
+                "name": "cloudsql-instance-1-valid",
+                "project": "my-test-project",
+                "region": "us-central1",
+                "selfLink": "https://www.googleapis.com/sql/v1beta4/projects/my-test-project/instances/cloudsql-instance-1-valid",
+                "settings": {
+                    "activationPolicy": "ALWAYS",
+                    "backupConfiguration": {
+                        "binaryLogEnabled": true,
+                        "enabled": true,
+                        "kind": "sql#backupConfiguration",
+                        "startTime": "15:00"
+                    },
+                    "dataDiskSizeGb": "10",
+                    "dataDiskType": "PD_SSD",
+                    "ipConfiguration": {
+                        "ipv4Enabled": true
+                    },
+                    "kind": "sql#settings",
+                    "locationPreference": {
+                        "kind": "sql#locationPreference",
+                        "zone": "us-central1-a"
+                    },
+                    "maintenanceWindow": {
+                        "day": 0,
+                        "hour": 0,
+                        "kind": "sql#maintenanceWindow"
+                    },
+                    "pricingPlan": "PER_USE",
+                    "replicationType": "SYNCHRONOUS",
+                    "settingsVersion": "0",
+                    "storageAutoResize": true,
+                    "storageAutoResizeLimit": "0",
+                    "tier": "db-n1-standard-1",
+                    "userLabels": {
+                        "label1": "label1-value",
+                        "label2": "label2-valueOK"
+                    }
+                },
+                "state": "PENDING_CREATE"
+            }
+        }
+    },
+    {
+        "name": "//cloudsql.googleapis.com/projects/my-test-project/instances/cloudsql-instance-1-invalid-missing-labels",
+        "asset_type": "sqladmin.googleapis.com/Instance",
+        "resource": {
+            "version": "v1beta4",
+            "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/sqladmin/v1beta4/rest",
+            "discovery_name": "DatabaseInstance",
+            "data": {
+                "backendType": "SECOND_GEN",
+                "connectionName": "my-test-project:us-central1:cloudsql-instance-1-invalid-missing-labels",
+                "databaseVersion": "MYSQL_5_7",
+                "gceZone": "us-central1-a",
+                "instanceType": "CLOUD_SQL_INSTANCE",
+                "kind": "sql#instance",
+                "name": "cloudsql-instance-1-invalid-missing-labels",
+                "project": "my-test-project",
+                "region": "us-central1",
+                "selfLink": "https://www.googleapis.com/sql/v1beta4/projects/my-test-project/instances/cloudsql-instance-1-invalid-missing-labels",
+                "settings": {
+                    "activationPolicy": "ALWAYS",
+                    "backupConfiguration": {
+                        "binaryLogEnabled": true,
+                        "enabled": true,
+                        "kind": "sql#backupConfiguration",
+                        "startTime": "15:00"
+                    },
+                    "dataDiskSizeGb": "10",
+                    "dataDiskType": "PD_SSD",
+                    "ipConfiguration": {
+                        "ipv4Enabled": true
+                    },
+                    "kind": "sql#settings",
+                    "locationPreference": {
+                        "kind": "sql#locationPreference",
+                        "zone": "us-central1-a"
+                    },
+                    "maintenanceWindow": {
+                        "day": 0,
+                        "hour": 0,
+                        "kind": "sql#maintenanceWindow"
+                    },
+                    "pricingPlan": "PER_USE",
+                    "replicationType": "SYNCHRONOUS",
+                    "settingsVersion": "0",
+                    "storageAutoResize": true,
+                    "storageAutoResizeLimit": "0",
+                    "tier": "db-n1-standard-1"
+                },
+                "state": "PENDING_CREATE"
+            }
+        }
+    },
+    {
+        "name": "//cloudsql.googleapis.com/projects/my-test-project/instances/cloudsql-instance-1-invalid-missing-label1",
+        "asset_type": "sqladmin.googleapis.com/Instance",
+        "resource": {
+            "version": "v1beta4",
+            "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/sqladmin/v1beta4/rest",
+            "discovery_name": "DatabaseInstance",
+            "data": {
+                "backendType": "SECOND_GEN",
+                "connectionName": "my-test-project:us-central1:cloudsql-instance-1-invalid-missing-label1",
+                "databaseVersion": "MYSQL_5_7",
+                "gceZone": "us-central1-a",
+                "instanceType": "CLOUD_SQL_INSTANCE",
+                "kind": "sql#instance",
+                "name": "cloudsql-instance-1-invalid-missing-label1",
+                "project": "my-test-project",
+                "region": "us-central1",
+                "selfLink": "https://www.googleapis.com/sql/v1beta4/projects/my-test-project/instances/cloudsql-instance-1-invalid-missing-label1",
+                "settings": {
+                    "activationPolicy": "ALWAYS",
+                    "backupConfiguration": {
+                        "binaryLogEnabled": true,
+                        "enabled": true,
+                        "kind": "sql#backupConfiguration",
+                        "startTime": "15:00"
+                    },
+                    "dataDiskSizeGb": "10",
+                    "dataDiskType": "PD_SSD",
+                    "ipConfiguration": {
+                        "ipv4Enabled": true
+                    },
+                    "kind": "sql#settings",
+                    "locationPreference": {
+                        "kind": "sql#locationPreference",
+                        "zone": "us-central1-a"
+                    },
+                    "maintenanceWindow": {
+                        "day": 0,
+                        "hour": 0,
+                        "kind": "sql#maintenanceWindow"
+                    },
+                    "pricingPlan": "PER_USE",
+                    "replicationType": "SYNCHRONOUS",
+                    "settingsVersion": "0",
+                    "storageAutoResize": true,
+                    "storageAutoResizeLimit": "0",
+                    "tier": "db-n1-standard-1",
+                    "userLabels": {
+                        "label2": "label2-valueOKTOO"
+                    }
+                },
+                "state": "PENDING_CREATE"
+            }
+        }
+    },
+    {
+        "name": "//cloudsql.googleapis.com/projects/my-test-project/instances/cloudsql-instance-1-invalid-missing-label2",
+        "asset_type": "sqladmin.googleapis.com/Instance",
+        "resource": {
+            "version": "v1beta4",
+            "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/sqladmin/v1beta4/rest",
+            "discovery_name": "DatabaseInstance",
+            "data": {
+                "backendType": "SECOND_GEN",
+                "connectionName": "my-test-project:us-central1:cloudsql-instance-1-invalid-missing-label2",
+                "databaseVersion": "MYSQL_5_7",
+                "gceZone": "us-central1-a",
+                "instanceType": "CLOUD_SQL_INSTANCE",
+                "kind": "sql#instance",
+                "name": "cloudsql-instance-1-invalid-missing-label2",
+                "project": "my-test-project",
+                "region": "us-central1",
+                "selfLink": "https://www.googleapis.com/sql/v1beta4/projects/my-test-project/instances/cloudsql-instance-1-invalid-missing-label2",
+                "settings": {
+                    "activationPolicy": "ALWAYS",
+                    "backupConfiguration": {
+                        "binaryLogEnabled": true,
+                        "enabled": true,
+                        "kind": "sql#backupConfiguration",
+                        "startTime": "15:00"
+                    },
+                    "dataDiskSizeGb": "10",
+                    "dataDiskType": "PD_SSD",
+                    "ipConfiguration": {
+                        "ipv4Enabled": true
+                    },
+                    "kind": "sql#settings",
+                    "locationPreference": {
+                        "kind": "sql#locationPreference",
+                        "zone": "us-central1-a"
+                    },
+                    "maintenanceWindow": {
+                        "day": 0,
+                        "hour": 0,
+                        "kind": "sql#maintenanceWindow"
+                    },
+                    "pricingPlan": "PER_USE",
+                    "replicationType": "SYNCHRONOUS",
+                    "settingsVersion": "0",
+                    "storageAutoResize": true,
+                    "storageAutoResizeLimit": "0",
+                    "tier": "db-n1-standard-1",
+                    "userLabels": {
+                        "label1": "label1-value"
+                    }
+                },
+                "state": "PENDING_CREATE"
+            }
+        }
+    },
+    {
+        "name": "//cloudsql.googleapis.com/projects/my-test-project/instances/cloudsql-instance-1-invalid-label1-and-label2-bad-values",
+        "asset_type": "sqladmin.googleapis.com/Instance",
+        "resource": {
+            "version": "v1beta4",
+            "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/sqladmin/v1beta4/rest",
+            "discovery_name": "DatabaseInstance",
+            "data": {
+                "backendType": "SECOND_GEN",
+                "connectionName": "my-test-project:us-central1:cloudsql-instance-1-invalid-label1-and-label2-bad-values",
+                "databaseVersion": "MYSQL_5_7",
+                "gceZone": "us-central1-a",
+                "instanceType": "CLOUD_SQL_INSTANCE",
+                "kind": "sql#instance",
+                "name": "cloudsql-instance-1-invalid-label1-and-label2-bad-values",
+                "project": "my-test-project",
+                "region": "us-central1",
+                "selfLink": "https://www.googleapis.com/sql/v1beta4/projects/my-test-project/instances/cloudsql-instance-1-invalid-label1-and-label2-bad-values",
+                "settings": {
+                    "activationPolicy": "ALWAYS",
+                    "backupConfiguration": {
+                        "binaryLogEnabled": true,
+                        "enabled": true,
+                        "kind": "sql#backupConfiguration",
+                        "startTime": "15:00"
+                    },
+                    "dataDiskSizeGb": "10",
+                    "dataDiskType": "PD_SSD",
+                    "ipConfiguration": {
+                        "ipv4Enabled": true
+                    },
+                    "kind": "sql#settings",
+                    "locationPreference": {
+                        "kind": "sql#locationPreference",
+                        "zone": "us-central1-a"
+                    },
+                    "maintenanceWindow": {
+                        "day": 0,
+                        "hour": 0,
+                        "kind": "sql#maintenanceWindow"
+                    },
+                    "pricingPlan": "PER_USE",
+                    "replicationType": "SYNCHRONOUS",
+                    "settingsVersion": "0",
+                    "storageAutoResize": true,
+                    "storageAutoResizeLimit": "0",
+                    "tier": "db-n1-standard-1",
+                    "userLabels": {
+                        "label1": "label1-bad-value",
+                        "label2": "label2-bad-value"
+                    }
+                },
+                "state": "PENDING_CREATE"
+            }
+        }
+    }
+]

--- a/validator/test/fixtures/enforce_labels/assets/compute/disks/data.json
+++ b/validator/test/fixtures/enforce_labels/assets/compute/disks/data.json
@@ -19,7 +19,7 @@
                 "labels": {
                     "disk-label": "value",
                     "label1": "label1-value",
-                    "label2": "label2-value"
+                    "label2": "label2-valueOK"
                 },
                 "lastAttachTimestamp": "2018-09-19T12:52:28.130-07:00",
                 "license": [
@@ -101,7 +101,7 @@
                 "labelFingerprint": "Iv/ZLuyPnZw=",
                 "labels": {
                     "disk-label": "value",
-                    "label2": "label2-value"
+                    "label2": "label2-valueOKTOO"
                 },
                 "lastAttachTimestamp": "2018-09-19T12:52:28.130-07:00",
                 "license": [
@@ -154,6 +154,50 @@
                     "1000205"
                 ],
                 "name": "instance-1-invalid-disk-missing-label2",
+                "physicalBlockSizeBytes": "4096",
+                "selfLink": "https://www.googleapis.com/compute/v1/projects/my-test-project/zones/us-east1-b/disks/instance-1",
+                "sizeGb": "10",
+                "sourceImage": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20180911",
+                "sourceImageId": "6964739134299892958",
+                "status": "READY",
+                "type": "https://www.googleapis.com/compute/v1/projects/my-test-project/zones/us-east1-b/diskTypes/pd-standard",
+                "user": [
+                    "https://www.googleapis.com/compute/v1/projects/my-test-project/zones/us-east1-b/instances/instance-1"
+                ],
+                "zone": "https://www.googleapis.com/compute/v1/projects/my-test-project/zones/us-east1-b"
+            }
+        }
+    },
+    {
+        "name": "//compute.googleapis.com/projects/my-test-project/zones/us-east1-b/disks/instance-1-invalid-disk-label1-and-label2-bad-values",
+        "asset_type": "compute.googleapis.com/Disk",
+        "resource": {
+            "version": "v1",
+            "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+            "discovery_name": "Disk",
+            "parent": "//cloudresourcemanager.googleapis.com/projects/402901960755",
+            "data": {
+                "creationTimestamp": "2018-09-19T12:52:28.128-07:00",
+                "guestOsFeature": [
+                    {
+                        "type": "VIRTIO_SCSI_MULTIQUEUE"
+                    }
+                ],
+                "id": "5899079137373394452",
+                "labelFingerprint": "Iv/ZLuyPnZw=",
+                "labels": {
+                    "disk-label": "value",
+                    "label1": "label1-bad-value",
+                    "label2": "label2-bad-value"
+                },
+                "lastAttachTimestamp": "2018-09-19T12:52:28.130-07:00",
+                "license": [
+                    "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/licenses/debian-9-stretch"
+                ],
+                "licenseCode": [
+                    "1000205"
+                ],
+                "name": "instance-1-invalid-disk-label1-and-label2-bad",
                 "physicalBlockSizeBytes": "4096",
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/my-test-project/zones/us-east1-b/disks/instance-1",
                 "sizeGb": "10",

--- a/validator/test/fixtures/enforce_labels/assets/compute/images/data.json
+++ b/validator/test/fixtures/enforce_labels/assets/compute/images/data.json
@@ -20,8 +20,8 @@
                 "labelFingerprint": "bdw3YK9Nc14=",
                 "labels": {
                     "image-label": "value",
-                    "label1": "another-value",
-                    "label2": "another-one"
+                    "label1": "label1-value",
+                    "label2": "label2-valueOK"
                 },
                 "license": [
                     "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/licenses/debian-9-stretch"
@@ -93,7 +93,7 @@
                 "labelFingerprint": "bdw3YK9Nc14=",
                 "labels": {
                     "image-label": "value",
-                    "label2": "another-one"
+                    "label2": "label2-valueOKTOO"
                 },
                 "license": [
                     "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/licenses/debian-9-stretch"
@@ -131,7 +131,7 @@
                 "labelFingerprint": "bdw3YK9Nc14=",
                 "labels": {
                     "image-label": "value",
-                    "label1": "another-one"
+                    "label1": "label1-value"
                 },
                 "license": [
                     "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/licenses/debian-9-stretch"
@@ -140,6 +140,45 @@
                     "1000205"
                 ],
                 "name": "test-invalid-image-missing-label2",
+                "selfLink": "https://www.googleapis.com/compute/v1/projects/my-own-project/global/images/test-image-1",
+                "sourceDisk": "https://www.googleapis.com/compute/v1/projects/my-own-project/zones/us-east1-b/disks/instance-1",
+                "sourceDiskId": "5899079137373394452",
+                "sourceType": "RAW",
+                "status": "READY"
+            }
+        }
+    },
+    {
+        "name": "//compute.googleapis.com/projects/my-own-project/global/images/test-invalid-image-label1-and-label2-bad-values",
+        "asset_type": "compute.googleapis.com/Image",
+        "resource": {
+            "version": "v1",
+            "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+            "discovery_name": "Image",
+            "parent": "//cloudresourcemanager.googleapis.com/projects/402901960755",
+            "data": {
+                "archiveSizeBytes": "1709589952",
+                "creationTimestamp": "2019-05-15T09:00:22.657-07:00",
+                "diskSizeGb": "10",
+                "guestOsFeature": [
+                    {
+                        "type": "VIRTIO_SCSI_MULTIQUEUE"
+                    }
+                ],
+                "id": "8858092298948413817",
+                "labelFingerprint": "bdw3YK9Nc14=",
+                "labels": {
+                    "image-label": "value",
+                    "label1": "label1-bad-value",
+                    "label2": "label2-bad-value"
+                },
+                "license": [
+                    "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/licenses/debian-9-stretch"
+                ],
+                "licenseCode": [
+                    "1000205"
+                ],
+                "name": "test-invalid-image-label1-and-label2-bad-values",
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/my-own-project/global/images/test-image-1",
                 "sourceDisk": "https://www.googleapis.com/compute/v1/projects/my-own-project/zones/us-east1-b/disks/instance-1",
                 "sourceDiskId": "5899079137373394452",

--- a/validator/test/fixtures/enforce_labels/assets/compute/instances/data.json
+++ b/validator/test/fixtures/enforce_labels/assets/compute/instances/data.json
@@ -35,7 +35,7 @@
                     "dataflow_job_id": "2018-10-02_12_46_57-16714086278907465014",
                     "dataflow_job_name": "ps-to-bq-new-testing-topic",
                     "label1": "label1-value",
-                    "label2": "some-value"
+                    "label2": "label2-valueOK"
                 },
                 "machineType": "https://www.googleapis.com/compute/v1/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/machineTypes/n1-standard-4",
                 "name": "valid-instance-8hz5",
@@ -214,7 +214,7 @@
                 "labels": {
                     "dataflow_job_id": "2018-10-02_12_46_57-16714086278907465014",
                     "dataflow_job_name": "ps-to-bq-new-testing-topic",
-                    "label2": "some-value"
+                    "label2": "label2-valueOK"
                 },
                 "machineType": "https://www.googleapis.com/compute/v1/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/machineTypes/n1-standard-4",
                 "name": "invalid-instance-missing-label1-8hz5",
@@ -306,7 +306,7 @@
                 "labels": {
                     "dataflow_job_id": "2018-10-02_12_46_57-16714086278907465014",
                     "dataflow_job_name": "ps-to-bq-new-testing-topic",
-                    "label1": "some-value"
+                    "label1": "label1-value"
                 },
                 "machineType": "https://www.googleapis.com/compute/v1/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/machineTypes/n1-standard-4",
                 "name": "invalid-instance-missing-label2-8hz5",
@@ -333,6 +333,99 @@
                     "preemptible": false
                 },
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/instances/invalid-instance-missing-label2-8hz5",
+                "serviceAccount": [
+                    {
+                        "email": "216968792402-compute@developer.gserviceaccount.com",
+                        "scope": [
+                            "https://www.googleapis.com/auth/any-api",
+                            "https://www.googleapis.com/auth/bigquery",
+                            "https://www.googleapis.com/auth/cloud-platform",
+                            "https://www.googleapis.com/auth/compute",
+                            "https://www.googleapis.com/auth/datastore",
+                            "https://www.googleapis.com/auth/devstorage.full_control",
+                            "https://www.googleapis.com/auth/logging.write",
+                            "https://www.googleapis.com/auth/monitoring",
+                            "https://www.googleapis.com/auth/ndev.cloudman",
+                            "https://www.googleapis.com/auth/pubsub",
+                            "https://www.googleapis.com/auth/userinfo.email"
+                        ]
+                    }
+                ],
+                "startRestricted": false,
+                "status": "RUNNING",
+                "tags": {
+                    "fingerprint": "Loc0dSkS+b8=",
+                    "tag": [
+                        "dataflow"
+                    ]
+                },
+                "zone": "https://www.googleapis.com/compute/v1/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b"
+            }
+        }
+    },
+    {
+        "name": "//compute.googleapis.com/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/instances/invalid-instance-with-label1-and-label2-bad-values",
+        "asset_type": "compute.googleapis.com/Instance",
+        "resource": {
+            "version": "v1",
+            "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+            "discovery_name": "Instance",
+            "parent": "//cloudresourcemanager.googleapis.com/projects/216968792402",
+            "data": {
+                "canIpForward": false,
+                "cpuPlatform": "Intel Haswell",
+                "creationTimestamp": "2018-11-01T12:44:57.303-07:00",
+                "deletionProtection": false,
+                "description": "InstanceTemplate created for Dataflow job: 2018-10-02_12_46_57-16714086278907465014",
+                "disk": [
+                    {
+                        "autoDelete": true,
+                        "boot": true,
+                        "deviceName": "persistent-disk-0",
+                        "index": 0,
+                        "interface": "SCSI",
+                        "license": [
+                            "https://www.googleapis.com/compute/v1/projects/clouddataflow-readonly/global/licenses/dataflow-owned-resource",
+                            "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/licenses/cos"
+                        ],
+                        "mode": "READ_WRITE",
+                        "source": "https://www.googleapis.com/compute/v1/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/disks/invalid-instance-with-label1-and-label2-bad-values",
+                        "type": "PERSISTENT"
+                    }
+                ],
+                "id": "1153916624998689114",
+                "labelFingerprint": "C1H1XlV7n1k=",
+                "labels": {
+                    "dataflow_job_id": "2018-10-02_12_46_57-16714086278907465014",
+                    "dataflow_job_name": "ps-to-bq-new-testing-topic",
+                    "label1": "label1-with-bad-value",
+                    "label2": "label2-with-bad-value"
+                },
+                "machineType": "https://www.googleapis.com/compute/v1/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/machineTypes/n1-standard-4",
+                "name": "invalid-instance-missing-label1-and-label2-bad-values",
+                "networkInterface": [
+                    {
+                        "accessConfig": [
+                            {
+                                "externalIp": "35.226.29.59",
+                                "name": "EXTERNAL NAT",
+                                "networkTier": "PREMIUM",
+                                "type": "ONE_TO_ONE_NAT"
+                            }
+                        ],
+                        "fingerprint": "BZYSgscuzgc=",
+                        "ipAddress": "10.128.0.3",
+                        "name": "nic0",
+                        "network": "https://www.googleapis.com/compute/v1/projects/vpc-sc-pub-sub-billing-alerts/global/networks/default",
+                        "subnetwork": "https://www.googleapis.com/compute/v1/projects/vpc-sc-pub-sub-billing-alerts/regions/us-central1/subnetworks/default"
+                    }
+                ],
+                "scheduling": {
+                    "automaticRestart": true,
+                    "onHostMaintenance": "MIGRATE",
+                    "preemptible": false
+                },
+                "selfLink": "https://www.googleapis.com/compute/v1/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/instances/invalid-instance-with-label1-and-label2-bad-values",
                 "serviceAccount": [
                     {
                         "email": "216968792402-compute@developer.gserviceaccount.com",

--- a/validator/test/fixtures/enforce_labels/assets/compute/snapshots/data.json
+++ b/validator/test/fixtures/enforce_labels/assets/compute/snapshots/data.json
@@ -15,7 +15,7 @@
                 "labels": {
                     "snapshot-label": "some-value",
                     "label1": "label1-value",
-                    "label2": "label2-value"
+                    "label2": "label2-valueOK"
                 },
                 "license": [
                     "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/licenses/debian-9-stretch"
@@ -83,7 +83,7 @@
                 "labelFingerprint": "WwfUv8tjyW8=",
                 "labels": {
                     "snapshot-label": "some-value",
-                    "label2": "label2-value"
+                    "label2": "label2-valueOKTOO"
                 },
                 "license": [
                     "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/licenses/debian-9-stretch"
@@ -129,6 +129,43 @@
                 ],
                 "name": "snapshot-1-invalid-missing-label2",
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/my-test-project/global/snapshots/snapshot-1-invalid-missing-label2",
+                "sourceDisk": "https://www.googleapis.com/compute/v1/projects/my-test-project/zones/us-east1-b/disks/instance-1",
+                "sourceDiskId": "5899079137373394452",
+                "status": "READY",
+                "storageBytes": "1709589952",
+                "storageBytesStatus": "UP_TO_DATE",
+                "storageLocation": [
+                    "us-east1"
+                ]
+            }
+        }
+    },
+    {
+        "name": "//compute.googleapis.com/projects/my-test-project/global/snapshots/snapshot-1-invalid-label1-and-label2-bad-values",
+        "asset_type": "compute.googleapis.com/Snapshot",
+        "resource": {
+            "version": "v1",
+            "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+            "discovery_name": "Snapshot",
+            "parent": "//cloudresourcemanager.googleapis.com/projects/402901960755",
+            "data": {
+                "creationTimestamp": "2019-06-07T07:46:35.102-07:00",
+                "diskSizeGb": "10",
+                "id": "6214628013742999077",
+                "labelFingerprint": "WwfUv8tjyW8=",
+                "labels": {
+                    "snapshot-label": "some-value",
+                    "label1": "label1-bad-value",
+                    "label2": "label2-bad-value"
+                },
+                "license": [
+                    "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/licenses/debian-9-stretch"
+                ],
+                "licenseCode": [
+                    "1000205"
+                ],
+                "name": "snapshot-1-invalid-label1-and-label2-bad-values",
+                "selfLink": "https://www.googleapis.com/compute/v1/projects/my-test-project/global/snapshots/snapshot-1-invalid-label1-and-label2-bad-values",
                 "sourceDisk": "https://www.googleapis.com/compute/v1/projects/my-test-project/zones/us-east1-b/disks/instance-1",
                 "sourceDiskId": "5899079137373394452",
                 "status": "READY",

--- a/validator/test/fixtures/enforce_labels/assets/projects/data.json
+++ b/validator/test/fixtures/enforce_labels/assets/projects/data.json
@@ -10,8 +10,8 @@
       "data": {
         "createTime": "2018-09-19T19:32:59.43Z",
         "labels": {
-          "label1": "value3",
-          "label2": "value2"
+          "label1": "label1-value",
+          "label2": "label2-valueOK"
         },
         "lifecycleState": "ACTIVE",
         "name": "valid-project-test",
@@ -56,8 +56,8 @@
       "data": {
         "createTime": "2019-03-02T01:59:22.288Z",
         "labels": {
-          "test-label": "test-label-matching-value",
-          "label1": "value2"
+          "test-label": "test-label-value",
+          "label1": "label1-value"
         },
         "lifecycleState": "ACTIVE",
         "name": "invalid-project-missing-label2",
@@ -82,7 +82,7 @@
         "createTime": "2019-03-02T01:59:22.288Z",
         "labels": {
           "test-label": "test-label-matching-value",
-          "label2": "value2"
+          "label2": "label2-valueOKTOO"
         },
         "lifecycleState": "ACTIVE",
         "name": "invalid-project-missing-label2",
@@ -91,8 +91,34 @@
           "type": "organization"
         },
         "projectId": "invalid-project-missing-label1",
-        "projectNumber": "357960133769"
+        "projectNumber": "357960133899"
+      }
+    }
+  },
+  {
+    "name": "//cloudresourcemanager.googleapis.com/projects/357960133233",
+    "asset_type": "cloudresourcemanager.googleapis.com/Project",
+    "resource": {
+      "version": "v1beta1",
+      "discovery_document_uri": "https://cloudresourcemanager.googleapis.com/$discovery/rest?version=v1beta1",
+      "discovery_name": "Project",
+      "parent": "//cloudresourcemanager.googleapis.com/organizations/382777088978",
+      "data": {
+        "createTime": "2019-03-02T01:59:22.288Z",
+        "labels": {
+          "label1": "test-label1-bad-value",
+          "label2": "test-label2-bad-value"
+        },
+        "lifecycleState": "ACTIVE",
+        "name": "invalid-project-label1-and-label2-with-bad-values",
+        "parent": {
+          "id": "382777088978",
+          "type": "organization"
+        },
+        "projectId": "invalid-project-label-issues",
+        "projectNumber": "357960133233"
       }
     }
   }
 ]
+

--- a/validator/test/fixtures/enforce_labels/constraints/require_labels/data.yaml
+++ b/validator/test/fixtures/enforce_labels/constraints/require_labels/data.yaml
@@ -15,7 +15,7 @@
 apiVersion: constraints.gatekeeper.sh/v1alpha1
 kind: GCPGCPResourceLabelsV1ConstraintV1
 metadata:
-  name: require_labels
+  name: enforce_labels
 spec:
   severity: high
   match:
@@ -23,4 +23,12 @@ spec:
       target: ["organization/*"]
   parameters: 
     mandatory_labels: ["label1", "label2"]
+    resource_types_to_scan:
+      - "cloudresourcemanager.googleapis.com/Project"
+      - "storage.googleapis.com/Bucket"
+      - "compute.googleapis.com/Instance"
+      - "compute.googleapis.com/Image"
+      - "compute.googleapis.com/Disk"
+      - "compute.googleapis.com/Snapshot"
+      - "google.bigtable.Instance"
   

--- a/validator/test/fixtures/enforce_labels/constraints/require_labels/data.yaml
+++ b/validator/test/fixtures/enforce_labels/constraints/require_labels/data.yaml
@@ -22,7 +22,9 @@ spec:
     gcp:
       target: ["organization/*"]
   parameters: 
-    mandatory_labels: ["label1", "label2"]
+    mandatory_labels: 
+      - "label1": "^label1-value$"
+      - "label2": "^label2-value.*$"
     resource_types_to_scan:
       - "cloudresourcemanager.googleapis.com/Project"
       - "storage.googleapis.com/Bucket"
@@ -31,4 +33,5 @@ spec:
       - "compute.googleapis.com/Disk"
       - "compute.googleapis.com/Snapshot"
       - "google.bigtable.Instance"
+      - "sqladmin.googleapis.com/Instance"
   


### PR DESCRIPTION

New features:

- Adding optional parameter to provide a list of resource types to scan for.
- Adding feature to specify the pattern mandatory label's values should match (list of  label: pattern object in parameters)

Support for new resource types:

- Cloud SQL instances
- BigTable instances