### PR TITLE
Cloud sql updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,10 @@ You generally only need to submit a CLA once, so if you've already submitted one
 (even if it was for a different project), you probably don't need to do it
 again.
 
+In addition to a CLA, you will need to fork this repository and then perform a Pull 
+Request from there. Direct Pull Requests from this repository are not supported at 
+this time.
+
 ## Code reviews
 
 All submissions, including submissions by project members, require review. We

--- a/policies/templates/gcp_sql_public_ip_v1.yaml
+++ b/policies/templates/gcp_sql_public_ip_v1.yaml
@@ -27,23 +27,22 @@ spec:
           properties: {}
   targets:
     validation.gcp.forsetisecurity.org:
-      rego: |
-           #INLINE("validator/sql_public_ip.rego")
-           #
-           # Copyright 2018 Google LLC
-           #
-           # Licensed under the Apache License, Version 2.0 (the "License");
-           # you may not use this file except in compliance with the License.
-           # You may obtain a copy of the License at
-           #
-           #      http://www.apache.org/licenses/LICENSE-2.0
-           #
-           # Unless required by applicable law or agreed to in writing, software
-           # distributed under the License is distributed on an "AS IS" BASIS,
-           # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-           # See the License for the specific language governing permissions and
-           # limitations under the License.
-           #
+      rego: | #INLINE("validator/sql_public_ip.rego")
+         #
+         # Copyright 2019 Google LLC
+         #
+         # Licensed under the Apache License, Version 2.0 (the "License");
+         # you may not use this file except in compliance with the License.
+         # You may obtain a copy of the License at
+         #
+         #      http://www.apache.org/licenses/LICENSE-2.0
+         #
+         # Unless required by applicable law or agreed to in writing, software
+         # distributed under the License is distributed on an "AS IS" BASIS,
+         # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+         # See the License for the specific language governing permissions and
+         # limitations under the License.
+         #
            
            package templates.gcp.GCPSQLPublicIpConstraintV1
            

--- a/policies/templates/gcp_sql_public_ip_v1.yaml
+++ b/policies/templates/gcp_sql_public_ip_v1.yaml
@@ -50,17 +50,17 @@ spec:
            import data.validator.gcp.lib as lib
            
            deny[{
-           	"msg": message,
-           	"details": metadata,
+             "msg": message,
+             "details": metadata,
            }] {
-           	asset := input.asset
-            asset.asset_type == "sqladmin.googleapis.com/Instance"
+             asset := input.asset
+             asset.asset_type == "sqladmin.googleapis.com/Instance"
              
-            ip_config := lib.get_default(asset.resource.data.settings, "ipConfiguration", {})
-            ipv4 := lib.get_default(ip_config, "ipv4Enabled", true)
-            ipv4 == true           
-            
-            message := sprintf("%v is not allowed to have a Public IP.", [asset.name])
-            metadata := {"resource": asset.name}
+             ip_config := lib.get_default(asset.resource.data.settings, "ipConfiguration", {})
+             ipv4 := lib.get_default(ip_config, "ipv4Enabled", true)
+             ipv4 == true           
+             
+             message := sprintf("%v is not allowed to have a Public IP.", [asset.name])
+             metadata := {"resource": asset.name}
            }
            #ENDINLINE

--- a/policies/templates/gcp_sql_public_ip_v1.yaml
+++ b/policies/templates/gcp_sql_public_ip_v1.yaml
@@ -27,7 +27,8 @@ spec:
           properties: {}
   targets:
     validation.gcp.forsetisecurity.org:
-      rego: | #INLINE("validator/sql_public_ip.rego")
+      rego: |
+           #INLINE("validator/sql_public_ip.rego")
            #
            # Copyright 2018 Google LLC
            #
@@ -55,9 +56,11 @@ spec:
            	asset := input.asset
            	asset.asset_type == "sqladmin.googleapis.com/Instance"
            
-           	asset.resource.data.settings.ipConfiguration.ipv4Enabled == true
-           
-           	message := sprintf("%v is not allowed to have an external IP.", [asset.name])
+            ip_config := lib.get_default(asset.resource.data.settings, "ipConfiguration", {})
+            ipv4 := lib.get_default(ip_config, "ipv4Enabled", true)
+            ipv4 == true           
+
+           	message := sprintf("%v is not allowed to have a Public IP.", [asset.name])
            	metadata := {"resource": asset.name}
            }
            #ENDINLINE

--- a/policies/templates/gcp_sql_public_ip_v1.yaml
+++ b/policies/templates/gcp_sql_public_ip_v1.yaml
@@ -54,13 +54,13 @@ spec:
            	"details": metadata,
            }] {
            	asset := input.asset
-           	asset.asset_type == "sqladmin.googleapis.com/Instance"
-           
+            asset.asset_type == "sqladmin.googleapis.com/Instance"
+             
             ip_config := lib.get_default(asset.resource.data.settings, "ipConfiguration", {})
             ipv4 := lib.get_default(ip_config, "ipv4Enabled", true)
             ipv4 == true           
-
-           	message := sprintf("%v is not allowed to have a Public IP.", [asset.name])
-           	metadata := {"resource": asset.name}
+            
+            message := sprintf("%v is not allowed to have a Public IP.", [asset.name])
+            metadata := {"resource": asset.name}
            }
            #ENDINLINE

--- a/samples/sql_public_ip.yaml
+++ b/samples/sql_public_ip.yaml
@@ -1,5 +1,4 @@
-#
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,22 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-package templates.gcp.GCPSQLPublicIpConstraintV1
-
-import data.validator.gcp.lib as lib
-
-deny[{
-	"msg": message,
-	"details": metadata,
-}] {
-	asset := input.asset
-	asset.asset_type == "sqladmin.googleapis.com/Instance"
-
-	ip_config := lib.get_default(asset.resource.data.settings, "ipConfiguration", {})
-    ipv4 := lib.get_default(ip_config, "ipv4Enabled", true)
-    ipv4 == true 
-	
-	message := sprintf("%v is not allowed to have a Public IP.", [asset.name])
-	metadata := {"resource": asset.name}
-}
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPSQLPublicIpConstraintV1
+metadata:
+  name: prevent-public-ip-cloudsql
+  annotations:
+    description: Prevents a public IP from being assigned to a Cloud SQL instance.
+spec:
+  severity: high
+  match:
+    target: ["organization/*"]
+    exclude: [] # optional, default is no exclusions

--- a/validator/sql_public_ip.rego
+++ b/validator/sql_public_ip.rego
@@ -26,8 +26,8 @@ deny[{
 	asset.asset_type == "sqladmin.googleapis.com/Instance"
 
 	ip_config := lib.get_default(asset.resource.data.settings, "ipConfiguration", {})
-    ipv4 := lib.get_default(ip_config, "ipv4Enabled", true)
-    ipv4 == true 
+	ipv4 := lib.get_default(ip_config, "ipv4Enabled", true)
+	ipv4 == true 
 	
 	message := sprintf("%v is not allowed to have a Public IP.", [asset.name])
 	metadata := {"resource": asset.name}


### PR DESCRIPTION
This PR contains an update to the Cloud SQL template / rego for public IP constraints. The original logic did not cover an edge case scenario where the user can still deploy a public facing Cloud SQL instance by not declaring the ipv4_enabled setting (labeled Public Scenario 2 below). I did not increment the version naming to v2 but can if that is preferred.

Public Scenario 1:
```
settings {
    tier = "db-f1-micro"
    ip_configuration {
      ipv4_enabled = "true" #Sets a public IPV4 address
    }
```

Public Scenario 2
```
settings {
    tier = "db-f1-micro"
    }
```

Private Scenario
```
settings {
    tier = "db-f1-micro"
    ip_configuration {
      ipv4_enabled = "false"
    }
```

In addition, a sample constraint was added and the contribution guidelines were updated to make note of the fork requirement for clarity's sake.
- 