### PR TITLE
gcp_sql_ssl_v1.yaml

### DIFF
--- a/policies/templates/gcp_sql_ssl_v1.yaml
+++ b/policies/templates/gcp_sql_ssl_v1.yaml
@@ -28,67 +28,40 @@ spec:
   targets:
    validation.gcp.forsetisecurity.org:
       rego: | #INLINE("validator/sql_ssl.rego")
-
-            #
-
-            # Copyright 2018 Google LLC
-
-            #
-
-            # Licensed under the Apache License, Version 2.0 (the "License");
-
-            # you may not use this file except in compliance with the License.
-
-            # You may obtain a copy of the License at
-
-            #
-
-            #      http://www.apache.org/licenses/LICENSE-2.0
-
-            #
-
-            # Unless required by applicable law or agreed to in writing, software
-
-            # distributed under the License is distributed on an "AS IS" BASIS,
-
-            # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-
-            # See the License for the specific language governing permissions and
-
-            # limitations under the License.
-
-            #
-
-            
-
-            package templates.gcp.GCPSQLSSLV1
-
-            
-
-            import data.validator.gcp.lib as lib
-
-            
-
-            deny[{
-
-            	"msg": message,
-
-            	"details": metadata,
-
-            }] {
-
-            	asset := input.asset
-
-            	asset.asset_type == "sqladmin.googleapis.com/Instance"
-
-            	asset.resource.settings.ipConfiguration.requireSsl == false
-
-            
-
-            	message := sprintf("%v does not require SSL", [asset.name])
-
-            	metadata := {"resource": asset.name}
-
-            }
-
-            #ENDINLINE
+           #
+           # Copyright 2019 Google LLC
+           #
+           # Licensed under the Apache License, Version 2.0 (the "License");
+           # you may not use this file except in compliance with the License.
+           # You may obtain a copy of the License at
+           #
+           #      http://www.apache.org/licenses/LICENSE-2.0
+           #
+           # Unless required by applicable law or agreed to in writing, software
+           # distributed under the License is distributed on an "AS IS" BASIS,
+           # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+           # See the License for the specific language governing permissions and
+           # limitations under the License.
+           #
+           
+           package templates.gcp.GCPSQLSSLConstraintV1
+           
+           import data.validator.gcp.lib as lib
+           
+           deny[{
+           	"msg": message,
+           	"details": metadata,
+           }] {
+           	asset := input.asset
+           	asset.asset_type == "sqladmin.googleapis.com/Instance"
+           
+           	settings := asset.resource.data.settings
+           
+           	ipConfiguration := lib.get_default(settings, "ipConfiguration", {})
+           	requireSsl := lib.get_default(ipConfiguration, "requireSsl", false)
+           	requireSsl == false
+           
+           	message := sprintf("%v does not require SSL", [asset.name])
+           	metadata := {"resource": asset.name}
+           }
+           #ENDINLINE

--- a/validator/sql_ssl.rego
+++ b/validator/sql_ssl.rego
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-package templates.gcp.GCPSQLSSLV1
+package templates.gcp.GCPSQLSSLConstraintV1
 
 import data.validator.gcp.lib as lib
 


### PR DESCRIPTION
Updated the gcp_sql_ssl_v1.yaml template file to match the updated rego from #125 

- new inline rego
- updated copyright year
- fixed `package templates.gcp.GCPSQLSSLV1` to align with the constraint naming: `package templates.gcp.GCPSQLSSLConstraintV1`
- updated `sql_ssl.rego` with new package name