### PR TITLE
Updating bigtable resource type 

### DIFF
--- a/policies/templates/gcp_enforce_labels_v1.yaml
+++ b/policies/templates/gcp_enforce_labels_v1.yaml
@@ -24,22 +24,22 @@ spec:
         plural: gcpenforcelabelconstraintsv1
       validation:
         openAPIV3Schema:
-          properties: 
+          properties:
             mandatory_labels:
-              description: | 
-                "List of mandatory label objects to check for on all supported resources. 
+              description: |
+                "List of mandatory label objects to check for on all supported resources.
                 Label objects should be as follow:
-                label_key: label_value_regex_to_match 
+                label_key: label_value_regex_to_match
                 Each missing label will result in a violation for scanned resources.
                 Each mismatching label will result in a violation for scanned resources.
                 "
               type: array
               items: objects
             resource_types_to_scan:
-              description: | 
+              description: |
                 "Optional parameter: list of resource types to scan for labels.
                 Any resource that is not of these types will not raise any violation.
-      
+
                 If not passed, all tested resource types will be scanned for violations:
 
                 - cloudresourcemanager.googleapis.com/Project
@@ -48,7 +48,7 @@ spec:
                 - compute.googleapis.com/Image
                 - compute.googleapis.com/Disk
                 - compute.googleapis.com/Snapshot
-                - google.bigtable.Instance
+                - bigtableadmin.googleapis.com/Instance
                 - sqladmin.googleapis.com/Instance
                 - "dataproc.googleapis.com/Job"
                 - "dataproc.googleapis.com/Cluster"
@@ -104,7 +104,7 @@ spec:
        		"compute.googleapis.com/Image",
        		"compute.googleapis.com/Disk",
        		"compute.googleapis.com/Snapshot",
-       		"google.bigtable.Instance",
+       		"bigtableadmin.googleapis.com/Instance",
        		"sqladmin.googleapis.com/Instance",
        		"dataproc.googleapis.com/Job",
        		"dataproc.googleapis.com/Cluster",
@@ -132,13 +132,13 @@ spec:
        	# test if label exists in asset
        	resource_labels[label_key]
        
-       	# test if label value matches pattern passed as a parameter 
+       	# test if label value matches pattern passed as a parameter
        re_match(	label_value_pattern, resource_labels[label_key])
        }
        
        # get_labels for cloudsql instances
        get_labels(asset, non_standard_types) = resource_labels {
-       	# check if we have a non-standard type 
+       	# check if we have a non-standard type
        	asset.asset_type == non_standard_types[_]
        	asset.asset_type == "sqladmin.googleapis.com/Instance"
        	resource := asset.resource.data.settings
@@ -147,7 +147,7 @@ spec:
        
        # get_labels for gke cluster
        get_labels(asset, non_standard_types) = resource_labels {
-       	# check if we have a non-standard type 
+       	# check if we have a non-standard type
        	asset.asset_type == non_standard_types[_]
        	asset.asset_type == "container.googleapis.com/Cluster"
        	resource := asset.resource.data

--- a/validator/enforce_labels.rego
+++ b/validator/enforce_labels.rego
@@ -39,7 +39,7 @@ deny[{
 		"compute.googleapis.com/Image",
 		"compute.googleapis.com/Disk",
 		"compute.googleapis.com/Snapshot",
-		"google.bigtable.Instance",
+		"bigtableadmin.googleapis.com/Instance",
 		"sqladmin.googleapis.com/Instance",
 		"dataproc.googleapis.com/Job",
 		"dataproc.googleapis.com/Cluster",
@@ -67,13 +67,13 @@ label_is_valid(label_key, label_value_pattern, asset, non_standard_types) {
 	# test if label exists in asset
 	resource_labels[label_key]
 
-	# test if label value matches pattern passed as a parameter 
+	# test if label value matches pattern passed as a parameter
 re_match(	label_value_pattern, resource_labels[label_key])
 }
 
 # get_labels for cloudsql instances
 get_labels(asset, non_standard_types) = resource_labels {
-	# check if we have a non-standard type 
+	# check if we have a non-standard type
 	asset.asset_type == non_standard_types[_]
 	asset.asset_type == "sqladmin.googleapis.com/Instance"
 	resource := asset.resource.data.settings
@@ -82,7 +82,7 @@ get_labels(asset, non_standard_types) = resource_labels {
 
 # get_labels for gke cluster
 get_labels(asset, non_standard_types) = resource_labels {
-	# check if we have a non-standard type 
+	# check if we have a non-standard type
 	asset.asset_type == non_standard_types[_]
 	asset.asset_type == "container.googleapis.com/Cluster"
 	resource := asset.resource.data

--- a/validator/enforce_labels_test.rego
+++ b/validator/enforce_labels_test.rego
@@ -29,8 +29,8 @@ import data.test.fixtures.enforce_labels.assets.compute.instances as fixture_com
 import data.test.fixtures.enforce_labels.assets.compute.snapshots as fixture_compute_snapshots
 import data.test.fixtures.enforce_labels.assets.dataproc.clusters as fixture_dataproc_clusters
 import data.test.fixtures.enforce_labels.assets.dataproc.jobs as fixture_dataproc_jobs
-import data.test.fixtures.enforce_labels.assets.projects as fixture_projects
 import data.test.fixtures.enforce_labels.assets.gke as fixture_gke
+import data.test.fixtures.enforce_labels.assets.projects as fixture_projects
 
 # Importing the test constraint
 import data.test.fixtures.enforce_labels.constraints as fixture_constraints

--- a/validator/test/fixtures/enforce_labels/assets/bigtable/data.json
+++ b/validator/test/fixtures/enforce_labels/assets/bigtable/data.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "//bigtable.googleapis.com/projects/my-test-project/instances/test-bigtable-id-valid-labels",
-        "asset_type": "google.bigtable.Instance",
+        "asset_type": "bigtableadmin.googleapis.com/Instance",
         "resource": {
             "version": "v2",
             "discovery_document_uri": "https://bigtableadmin.googleapis.com/$discovery/rest",
@@ -20,7 +20,7 @@
     },
     {
         "name": "//bigtable.googleapis.com/projects/my-test-project/instances/test-bigtable-invalid-missing-labels",
-        "asset_type": "google.bigtable.Instance",
+        "asset_type": "bigtableadmin.googleapis.com/Instance",
         "resource": {
             "version": "v2",
             "discovery_document_uri": "https://bigtableadmin.googleapis.com/$discovery/rest",
@@ -35,7 +35,7 @@
     },
     {
         "name": "//bigtable.googleapis.com/projects/my-test-project/instances/test-bigtable-invalid-missing-label1",
-        "asset_type": "google.bigtable.Instance",
+        "asset_type": "bigtableadmin.googleapis.com/Instance",
         "resource": {
             "version": "v2",
             "discovery_document_uri": "https://bigtableadmin.googleapis.com/$discovery/rest",
@@ -53,7 +53,7 @@
     },
     {
         "name": "//bigtable.googleapis.com/projects/my-test-project/instances/test-bigtable-invalid-missing-label2",
-        "asset_type": "google.bigtable.Instance",
+        "asset_type": "bigtableadmin.googleapis.com/Instance",
         "resource": {
             "version": "v2",
             "discovery_document_uri": "https://bigtableadmin.googleapis.com/$discovery/rest",
@@ -71,7 +71,7 @@
     },
     {
         "name": "//bigtable.googleapis.com/projects/my-test-project/instances/test-bigtable-invalid-label1-and-label2-bad-values",
-        "asset_type": "google.bigtable.Instance",
+        "asset_type": "bigtableadmin.googleapis.com/Instance",
         "resource": {
             "version": "v2",
             "discovery_document_uri": "https://bigtableadmin.googleapis.com/$discovery/rest",

--- a/validator/test/fixtures/enforce_labels/constraints/data.yaml
+++ b/validator/test/fixtures/enforce_labels/constraints/data.yaml
@@ -20,8 +20,8 @@ spec:
   severity: high
   match:
     target: ["organization/*"]
-  parameters: 
-    mandatory_labels: 
+  parameters:
+    mandatory_labels:
       - "label1": "^label1-value$"
       - "label2": "^label2-value.*$"
     resource_types_to_scan:
@@ -31,7 +31,7 @@ spec:
       - "compute.googleapis.com/Image"
       - "compute.googleapis.com/Disk"
       - "compute.googleapis.com/Snapshot"
-      - "google.bigtable.Instance"
+      - "bigtableadmin.googleapis.com/Instance"
       - "sqladmin.googleapis.com/Instance"
       - "dataproc.googleapis.com/Job"
       - "dataproc.googleapis.com/Cluster"


### PR DESCRIPTION
CAI just released a new type for bigtable instances, clusters and table. Updating enforce label to match this change.