### PR TITLE
Fix inverted rule

### DIFF
--- a/policies/templates/gcp_gke_disable_legacy_endpoints_v1.yaml
+++ b/policies/templates/gcp_gke_disable_legacy_endpoints_v1.yaml
@@ -74,6 +74,7 @@ spec:
             legacy_endpoints_enabled(node_pool) {
             	nodeConfig := lib.get_default(node_pool, "config", {})
             	metadata := lib.get_default(nodeConfig, "metadata", {})
-            	legacy_endpoints_enabled := lib.get_default(metadata, "disable-legacy-endpoints", true)
+            	legacy_endpoints_enabled := lib.get_default(metadata, "disable-legacy-endpoints", "false")
+            	legacy_endpoints_enabled == "false"
             }
             #ENDINLINE

--- a/policies/templates/gcp_sql_maintenance_window_v1.yaml
+++ b/policies/templates/gcp_sql_maintenance_window_v1.yaml
@@ -60,9 +60,9 @@ spec:
         
         	# get the maintenance window object
         	maintenance_window := lib.get_default(asset.resource.data.settings, "maintenanceWindow", {})
+        
         	# non compliant when not found
         	maintenance_window == {}
-        
         
         	message := sprintf("%v missing maintenance window.", [asset.name])
         	metadata := {"resource": asset.name}

--- a/validator/gke_disable_legacy_endpoints.rego
+++ b/validator/gke_disable_legacy_endpoints.rego
@@ -41,5 +41,6 @@ deny[{
 legacy_endpoints_enabled(node_pool) {
 	nodeConfig := lib.get_default(node_pool, "config", {})
 	metadata := lib.get_default(nodeConfig, "metadata", {})
-	legacy_endpoints_enabled := lib.get_default(metadata, "disable-legacy-endpoints", true)
+	legacy_endpoints_enabled := lib.get_default(metadata, "disable-legacy-endpoints", "false")
+	legacy_endpoints_enabled == "false"
 }

--- a/validator/test/fixtures/gke_disable_legacy_endpoints/assets/data.json
+++ b/validator/test/fixtures/gke_disable_legacy_endpoints/assets/data.json
@@ -53,7 +53,7 @@
               "imageType": "COS",
               "machineType": "n1-standard-1",
               "metadata": {
-                "disable-legacy-endpoints": "true"
+                "disable-legacy-endpoints": "false"
               },
               "oauthScopes": [
                 "https://www.googleapis.com/auth/devstorage.read_only",
@@ -252,7 +252,7 @@
               "imageType": "COS",
               "machineType": "n1-standard-1",
               "metadata": {
-                "disable-legacy-endpoints": "true"
+                "disable-legacy-endpoints": "false"
               },
               "oauthScopes": [
                 "https://www.googleapis.com/auth/devstorage.read_only",


### PR DESCRIPTION
#172 
Fix:
- The rule is currenlty inverted, it detect as non compliant the nodepooll where legacy en points are disabled
- Wired: CAI json export containts the strings "true" and "false" instead of bolean true/false ...
- The  lib.get_default call use a bolean default value while is should be a string to stay consistent with CAI strange behavior
- fixture data.json updated accordingly 