### PR TITLE
add exemption list to kms

### DIFF
--- a/policies/templates/gcp_cmek_rotation_v1.yaml
+++ b/policies/templates/gcp_cmek_rotation_v1.yaml
@@ -53,8 +53,13 @@ spec:
            }] {
            	constraint := input.constraint
            	lib.get_constraint_params(constraint, params)
+           	exempt_list := lib.get_default(params, "exemptions", [])
            	asset := input.asset
            	asset.asset_type == "cloudkms.googleapis.com/CryptoKey"
+           
+           	# Check if resource is in exempt list
+           	matches := {asset.name} & cast_set(exempt_list)
+           	count(matches) == 0
            
            	# The rotation period for a key may be "never".  This results
            	# in the rotationPeriod attribute to be omitted from response

--- a/policies/templates/gcp_sql_maintenance_window_v1.yaml
+++ b/policies/templates/gcp_sql_maintenance_window_v1.yaml
@@ -60,9 +60,9 @@ spec:
         
         	# get the maintenance window object
         	maintenance_window := lib.get_default(asset.resource.data.settings, "maintenanceWindow", {})
+        
         	# non compliant when not found
         	maintenance_window == {}
-        
         
         	message := sprintf("%v missing maintenance window.", [asset.name])
         	metadata := {"resource": asset.name}

--- a/validator/cmek_rotation.rego
+++ b/validator/cmek_rotation.rego
@@ -23,8 +23,13 @@ deny[{
 }] {
 	constraint := input.constraint
 	lib.get_constraint_params(constraint, params)
+	exempt_list := lib.get_default(params, "exemptions", [])
 	asset := input.asset
 	asset.asset_type == "cloudkms.googleapis.com/CryptoKey"
+
+	# Check if resource is in exempt list
+	matches := {asset.name} & cast_set(exempt_list)
+	count(matches) == 0
 
 	# The rotation period for a key may be "never".  This results
 	# in the rotationPeriod attribute to be omitted from response

--- a/validator/cmek_rotation_test.rego
+++ b/validator/cmek_rotation_test.rego
@@ -36,6 +36,16 @@ all_violations_no_params[violation] {
 	violation := issues[_]
 }
 
+all_violations_exemptions[violation] {
+	resource := data.test.fixtures.cmek_rotation.assets[_]
+	constraint := data.test.fixtures.cmek_rotation.constraints.exemptions
+
+	issues := deny with input.asset as resource
+		 with input.constraint as constraint
+
+	violation := issues[_]
+}
+
 # Confirm total violations count
 test_cmek_rotation_violations_count {
 	count(all_violations) == 2
@@ -48,4 +58,8 @@ test_cmek_rotation_violations_no_params_count {
 test_cmek_violations_basic {
 	violation := all_violations[_]
 	violation.details.resource == "//cloudkms.googleapis.com/projects/test-project/locations/us-central1/keyRings/test-key-ring/cryptoKeys/rotation-never"
+}
+
+test_cmek_rotation_violations_exemptions_count {
+	count(all_violations_exemptions) == 1
 }

--- a/validator/test/fixtures/cmek_rotation/constraints/exemptions/data.yaml
+++ b/validator/test/fixtures/cmek_rotation/constraints/exemptions/data.yaml
@@ -1,0 +1,27 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPCMEKRotationConstraintV1
+metadata:
+  name: cmek_rotation_one_year
+spec:
+  severity: high
+  parameters:
+    # Valid time units are  "ns", "us" (or "µs"), "ms", "s", "m", "h"
+    # This is 365 days
+    period: 8760h
+    exemptions:
+      - //cloudkms.googleapis.com/projects/test-project/locations/us-central1/keyRings/test-key-ring/cryptoKeys/rotation-never
+


### PR DESCRIPTION
#56 
It is not possible to delete a key ring.
Adding an exemption list enable to mute the violations once fixed
fixture update with 1 more test
 