### PR TITLE
adds a script to create rule templates with CRD based naming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,5 +54,14 @@ audit: ## Run audit against real CAI dump data
 	@echo "Running config-validator audit ..."
 	@bash scripts/cft.sh -o "$(ORG_ID)" -f "$(FOLDER_ID)" -p "$(PROJECT_ID)" -b "$(BUCKET_NAME)" -e "$(EXPORT)"
 
+.PHONY: create_new_rule
+create_new_rule: ## Creates a new rule template with rego, template and sample files.
+	@echo "Creating files to start with. The files are copied from vm-external-ip rule."
+	@read -p "Enter resource name, like: vm, gke-node, cloud-dataproc: " resource; \
+	read -p "Enter feature name, like external-ip, image-version, top-level-component-jupyter:" feature; \
+	read -p "Enter version like v1,v2:" version; \
+	read -p "Enter human readable definition, dataproc_jupyter_should_exist:" human_definition; \
+	python3 scripts/create_new_rule.py $$resource $$feature $$version $$human_definition
+
 help: ## Prints help for targets with comments
 	@grep -E '^[a-zA-Z._-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "make \033[36m%- 30s\033[0m %s\n", $$1, $$2}'

--- a/scripts/create_new_rule.py
+++ b/scripts/create_new_rule.py
@@ -1,0 +1,76 @@
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+import os, sys, datetime
+import logging as log
+log.basicConfig(level=log.INFO)
+
+
+resource = sys.argv[1]
+resources = resource.split("-")
+feature = sys.argv[2]
+features =  feature.split("-")
+version = sys.argv[3]
+human_readable_name = sys.argv[4]
+
+metadata_name = "gcp-{}-{}-{}".format(resource.lower(),feature.lower(),version.lower()) 
+capital_resource = "".join(map(lambda x:x.capitalize(),resources))
+capital_feature = "".join(map(lambda x:x.capitalize(),features))
+
+crd_kind = "GCP{}{}Constraint{}".format(capital_resource,capital_feature,version.capitalize())
+crd_plural = "gcp{}{}constraints{}".format(capital_resource.lower(),capital_feature.lower(),version.capitalize().lower())
+year = datetime.datetime.now().strftime("%Y")
+
+log.info("CRD KIND %s",crd_kind)
+log.debug("CRD PLURAL %s",crd_plural)
+
+root_path = os.path.dirname(__file__)
+
+def render_and_write(template_file_name, write_path_and_filename, parameters={}):
+    
+    env = Environment(loader=FileSystemLoader(os.path.join(root_path,"rule_jinja_templates")))
+    template = env.get_template(template_file_name)
+    log.debug('Rendering from template: %s', template.name)
+    rendered_template = template.render(parameters)
+    log.debug(rendered_template)
+
+    with open(write_path_and_filename, 'wb') as out:
+        out.write(rendered_template.encode('utf-8'))
+    # write(path, rendered_content.encode('utf-8').strip())
+    log.debug('Template %s has been converted and written into %s',template_file_name, write_path_and_filename) 
+
+
+# render REGO 
+rego_filename = ("gcp-{}-{}.rego".format(resource.lower(),feature.lower())).replace("-","_")
+render_and_write(
+  template_file_name="validator.rego.jinja2",
+  write_path_and_filename= os.path.join(root_path,"..","validator",rego_filename),
+  parameters={"year":year,"crd_kind":crd_kind}
+  )
+log.info("%s has been created under the validator directory. In this file you define the rego rule.",rego_filename )
+
+# template file
+template_filename = "{}.yaml".format(metadata_name.lower().replace("-","_"))
+render_and_write(
+  template_file_name="constraint_template.yaml.jinja2",
+  write_path_and_filename=os.path.join(root_path,"..","policies","templates",template_filename),
+  parameters={
+    "year":year,
+    "crd_kind":crd_kind,
+    "crd_plural":crd_plural,
+    "metadata_name":metadata_name,
+    "validator_source_name":rego_filename
+    }
+)
+log.info("%s has been created under the policies/templates directory. In this file you define the parameters for your rego rule.",template_filename )
+
+
+sample_filename = ("gcp_{}_{}.yaml".format(resource.lower(),feature.lower())).replace("-","_")
+render_and_write(
+  template_file_name="sample.yaml.jinja2",
+  write_path_and_filename=os.path.join(root_path,"..","samples",sample_filename),
+  parameters={
+    "year":year,
+    "crd_kind":crd_kind,
+    "human_readable_name":human_readable_name
+    }
+)
+log.info("%s has been created under the samples directory. You should copy this file under policies/constraints and provide parameters.",sample_filename )

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,1 +1,2 @@
 PyYAML==5.1
+jinja2

--- a/scripts/rule_jinja_templates/constraint_template.yaml.jinja2
+++ b/scripts/rule_jinja_templates/constraint_template.yaml.jinja2
@@ -1,0 +1,40 @@
+# Copyright {{ year }} Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: templates.gatekeeper.sh/v1alpha1
+kind: ConstraintTemplate
+metadata:
+  name: {{ metadata_name }}
+  annotations:
+    # Example of tying a template to a CIS benchmark
+    benchmark: CIS11_5.03
+spec:
+  crd:
+    spec:
+      names:
+        kind: {{ crd_kind }}
+        plural: {{ crd_plural }}
+      validation:
+        openAPIV3Schema:
+          properties:
+            mode:
+              type: string
+              enum: [blacklist, whitelist]
+            instances:
+              type: array
+              items: string
+  targets:
+   validation.gcp.forsetisecurity.org:
+      rego: | #INLINE("validator/{{  validator_source_name }}")
+            #ENDINLINE

--- a/scripts/rule_jinja_templates/sample.yaml.jinja2
+++ b/scripts/rule_jinja_templates/sample.yaml.jinja2
@@ -1,0 +1,24 @@
+# Copyright {{ year }} Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: {{ crd_kind }}
+metadata:
+  name: {{ human_readable_name }}
+spec:
+  severity: high
+  parameters:
+    mode: "whitelist"
+    instances:
+      - //compute.googleapis.com/projects/test-project/zones/us-east1-b/instances/vm-external-ip-two

--- a/scripts/rule_jinja_templates/validator.rego.jinja2
+++ b/scripts/rule_jinja_templates/validator.rego.jinja2
@@ -1,0 +1,60 @@
+#
+# Copyright {{ year }} Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package templates.gcp.{{ crd_kind }}
+
+import data.validator.gcp.lib as lib
+
+###########################
+# Find Whitelist Violations
+###########################
+deny[{
+	"msg": message,
+	"details": metadata,
+}] {
+	constraint := input.constraint
+	lib.get_constraint_params(constraint, params)
+	asset := input.asset
+	asset.asset_type == "compute.googleapis.com/Instance"
+
+	# Find network access config block w/ external IP
+	instance := asset.resource.data
+	access_config := instance.networkInterfaces[_].accessConfigs
+	count(access_config) > 0
+
+	# Check if instance is in blacklist/whitelist
+	target_instances := params.instances
+	matches := {asset.name} & cast_set(target_instances)
+	target_instance_match_count(params.mode, desired_count)
+	count(matches) == desired_count
+
+	message := sprintf("%v is not allowed to have an external IP.", [asset.name])
+	metadata := {"access_config": access_config}
+}
+
+###########################
+# Rule Utilities
+###########################
+
+# Determine the overlap between instances under test and constraint
+# By default (whitelist), we violate if there isn't overlap
+target_instance_match_count(mode) = 0 {
+	mode != "blacklist"
+}
+
+target_instance_match_count(mode) = 1 {
+	mode == "blacklist"
+}


### PR DESCRIPTION
Since it is cumbersome to deal with CRD, metadata naming and creating all the rego, template and sample files, I have created a script that creates
- rego file
- template file
- sample file
by using Jinja2.

The templates are filled with vm-external-ip example. When you run `make create_new_rule` it asks for **resource**, **feature**, **version** and **human readable name**.