### PR TITLE
Update User Guide for Forseti

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -13,11 +13,9 @@
   * [For local development environments](#for-local-development-environments)
   * [For Production Environments](#for-production-environments)
 * [How to Use Forseti Config Validator](#how-to-use-forseti-config-validator)
-  * [Install Forseti](#install-forseti)
-  * [Policy Library Sync](#policy-library-sync)
-  * [Copy over policy library repository](#copy-over-policy-library-repository-deprecated)
-  * [How to change the run frequency of Forseti](#how-to-change-the-run-frequency-of-forseti)
-  * [How to handle scaling for large resource sets](#how-to-handle-scaling-for-large-resource-sets)
+  * [Deploy Forseti](#deploy-forseti)
+  * [Policy Library Sync from Git Repository](#policy-library-sync-from-git-repository)
+  * [Policy Library Sync from GCS](#policy-library-sync-from-gcs)
   * [How to connect violation results with Cloud Security Command Center (CSCC)](#how-to-connect-violation-results-with-cloud-security-command-center-cscc)
 * [End to end workflow with sample constraint](#end-to-end-workflow-with-sample-constraint)
 * [Contact Info](#contact-info)
@@ -424,42 +422,6 @@ Example result: ![GCS Bucket Content](user_guide_bucket.png)
 
 After this is done, Forseti will pick up the new policy library content in the
 next scanner run.
-
-### How to change the run frequency of Forseti
-
-The Forseti inventory and scanning processes is scheduled to run by a cron job.
-To update the run frequency of this cron job, you need to understand
-[the time format of a cron job](https://crontab.guru/). After you have your
-desired time format, you can update the run frequency by following the steps
-below:
-
-In main.tf, under module "forseti" include **forseti_run_frequency** and set the
-value to your desired time format. For example, <code><em>"0 */2 * *
-*"</em></code>.
-
-```
-   module "forseti" {
-      ...
-      forseti_run_frequency = "0 */2 * * *"
-    }
-```
-
-Run _terraform plan_ command to see the change and _terraform apply_ command to
-apply the change.
-
-### How to handle scaling for large resource sets
-
-If you want to scale for large resource sets, you need to add more RAM to your
-server**.** Upgrading the Forseti server VM to n1-standard-4 (15GB of RAM)
-should be able to handle most use cases. Depending on the state and size of your
-data, this may trigger a large number of violations. Currently GRPC has a
-payload size limitation of 4MB. If a scanner run results in > 4MB of violation
-data to be generated, that will result in an error.
-
-In the future, we will consider the following changes:
-
-*   Use streaming GRPC or paging the violation results.
-*   Split the dataset into multiple chunks and process them separately.
 
 ### How to connect violation results with Cloud Security Command Center (CSCC)
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -86,9 +86,13 @@ steps below to get everything setup. If you are planning on using the [Policy
 Library Sync feature of Forseti](#policy-library-sync), then you should also add
 a read-only user to the private repository which will be used by Forseti.
 
-#### Duplicate Public Repository
+This policy library can also be made public, but it is not recommended. By
+making your policy library public, it would be allowing others to see what you
+are and __ARE NOT__ scanning for.
 
-To run the follwoing commands, you will need to configure git to connect
+#### Duplicate Policy Library Repository
+
+To run the following commands, you will need to configure git to connect
 securely. It is recommended to connect with SSH. [Here is a helpful resource](https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh) for learning about how
 this works, including steps to set this up for GitHub repositories; other
 providers offer this feature as well.


### PR DESCRIPTION
The main change here is to improve the documentation for users who want to use the Policy Library sync with Forseti (either Git or GCS). I also removed some out-dated Forseti documentation from the user guide, and added a note about using a public repository for storing the user's Policy Library.

Fixes #189 and #183.