### PR TITLE
adds regex functionality to vm external ip detection

### DIFF
--- a/policies/templates/gcp_compute_external_ip_access_v1.yaml
+++ b/policies/templates/gcp_compute_external_ip_access_v1.yaml
@@ -31,6 +31,9 @@ spec:
             mode:
               type: string
               enum: [blacklist, whitelist]
+            match_mode:
+              type: string
+              enum: [exact, regex]
             instances:
               type: array
               items: string
@@ -58,7 +61,7 @@ spec:
             import data.validator.gcp.lib as lib
             
             ###########################
-            # Find Whitelist Violations
+            # Find Whitelist/Blacklist Violations
             ###########################
             deny[{
             	"msg": message,
@@ -75,10 +78,11 @@ spec:
             	count(access_config) > 0
             
             	# Check if instance is in blacklist/whitelist
+            	match_mode := lib.get_default(params, "match_mode", "exact")
             	target_instances := params.instances
-            	matches := {asset.name} & cast_set(target_instances)
-            	target_instance_match_count(params.mode, desired_count)
-            	count(matches) == desired_count
+            	trace(sprintf("asset name:%v, target_instances: %v, mode: %v, match_mode: %v", [asset.name, target_instances, params.mode, match_mode]))
+            
+            	instance_name_targeted(asset.name, target_instances, params.mode, match_mode)
             
             	message := sprintf("%v is not allowed to have an external IP.", [asset.name])
             	metadata := {"access_config": access_config}
@@ -87,14 +91,33 @@ spec:
             ###########################
             # Rule Utilities
             ###########################
-            
-            # Determine the overlap between instances under test and constraint
-            # By default (whitelist), we violate if there isn't overlap
-            target_instance_match_count(mode) = 0 {
-            	mode != "blacklist"
+            instance_name_targeted(asset_name, instance_filters, mode, match_mode) {
+            	mode == "whitelist"
+            	match_mode == "exact"
+            	matches := {asset_name} & cast_set(instance_filters)
+            	count(matches) == 0
             }
             
-            target_instance_match_count(mode) = 1 {
+            instance_name_targeted(asset_name, instance_filters, mode, match_mode) {
             	mode == "blacklist"
+            	match_mode == "exact"
+            	matches := {asset_name} & cast_set(instance_filters)
+            	count(matches) > 0
+            }
+            
+            instance_name_targeted(asset_name, instance_filters, mode, match_mode) {
+            	mode == "whitelist"
+            	match_mode == "regex"
+            	not re_match_name(asset_name, instance_filters)
+            }
+            
+            instance_name_targeted(asset_name, instance_filters, mode, match_mode) {
+            	mode == "blacklist"
+            	match_mode == "regex"
+            	re_match_name(asset_name, instance_filters)
+            }
+            
+            re_match_name(name, filters) {
+            	re_match(filters[_], name)
             }
             #ENDINLINE

--- a/validator/test/fixtures/vm_external_ip/constraints/forbid_external_ip_regex_blacklist_all/data.yaml
+++ b/validator/test/fixtures/vm_external_ip/constraints/forbid_external_ip_regex_blacklist_all/data.yaml
@@ -15,17 +15,11 @@
 apiVersion: constraints.gatekeeper.sh/v1alpha1
 kind: GCPComputeExternalIpAccessConstraintV1
 metadata:
-  name: forbid_external_ip_whitelist
+  name: forbid_external_ip_blacklist_all
 spec:
   severity: high
   parameters:
-    # modes can be [whitelist, blacklist]
-    mode: whitelist
-    # match_mode can be [exact, regex], default is exact.
+    mode: blacklist
     match_mode: regex
     instances:
-      # regex example:
-      - //compute.googleapis.com/projects/test-project2/.*
-      # exact match example:
-      - //compute.googleapis.com/projects/test-project/zones/us-east1-b/instances/vm-external-ip
-
+      - .*vm-external-ip.*

--- a/validator/test/fixtures/vm_external_ip/constraints/forbid_external_ip_regex_whitelist_all/data.yaml
+++ b/validator/test/fixtures/vm_external_ip/constraints/forbid_external_ip_regex_whitelist_all/data.yaml
@@ -15,17 +15,11 @@
 apiVersion: constraints.gatekeeper.sh/v1alpha1
 kind: GCPComputeExternalIpAccessConstraintV1
 metadata:
-  name: forbid_external_ip_whitelist
+  name: forbid_external_ip_whitelist_all
 spec:
   severity: high
   parameters:
-    # modes can be [whitelist, blacklist]
     mode: whitelist
-    # match_mode can be [exact, regex], default is exact.
     match_mode: regex
     instances:
-      # regex example:
-      - //compute.googleapis.com/projects/test-project2/.*
-      # exact match example:
-      - //compute.googleapis.com/projects/test-project/zones/us-east1-b/instances/vm-external-ip
-
+      - ".*vm-external-ip.*"


### PR DESCRIPTION
Adds regex based matching to external IP constraints. Now it is possible to whitelist all VMs with a naming convention such as ".*frontend.*"

