### PR TITLE
Add policy for resource naming convention

### DIFF
--- a/policies/templates/gcp_enforce_naming_v1.yaml
+++ b/policies/templates/gcp_enforce_naming_v1.yaml
@@ -1,0 +1,109 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: templates.gatekeeper.sh/v1alpha1
+kind: ConstraintTemplate
+metadata:
+  name: gcp-enforce-naming-v1
+spec:
+  crd:
+    spec:
+      names:
+        kind: GCPEnforceNamingConstraintV1
+        plural: gcpenforcenamingconstraintsv1
+      validation:
+        openAPIV3Schema:
+          properties:
+            naming_rules:
+              type: array
+              items:
+                type: object
+                properties:
+                  resource:
+                    type: string
+                  patterns:
+                    type: array
+                    items:
+                      type: string
+  targets:
+   validation.gcp.forsetisecurity.org:
+      rego: | #INLINE("validator/gcp_enforce_naming.rego")
+           #
+           # Copyright 2019 Google LLC
+           #
+           # Licensed under the Apache License, Version 2.0 (the "License");
+           # you may not use this file except in compliance with the License.
+           # You may obtain a copy of the License at
+           #
+           #      http://www.apache.org/licenses/LICENSE-2.0
+           #
+           # Unless required by applicable law or agreed to in writing, software
+           # distributed under the License is distributed on an "AS IS" BASIS,
+           # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+           # See the License for the specific language governing permissions and
+           # limitations under the License.
+           #
+           
+           package templates.gcp.GCPEnforceNamingConstraintV1
+           
+           import data.validator.gcp.lib as lib
+           
+           ###########################
+           # Find Whitelist Violations
+           ###########################
+           deny[{
+           	"msg": message,
+           	"details": metadata,
+           }] {
+           	constraint := input.constraint
+           	lib.get_constraint_params(constraint, params)
+           	asset := input.asset
+           	naming_rules := lib.get_default(params, "naming_rules", [])
+           	count(naming_rules) > 0 # make sure that we have some rules to validate
+           
+           	patterns := check_asset_and_return_its_rules(asset.asset_type, naming_rules)
+           	name := get_only_asset_name(asset.name)
+           	no_name_match(name, patterns)
+           	trace(sprintf("no match name:%v, patterns:%v", [name, patterns]))
+           
+           	message := sprintf("%v does not obey the naming convention. Full address: %v", [name, asset.name])
+           	metadata := {
+           		"asset_name": name,
+           		"asset_full_address": asset.name,
+           		"patterns": patterns,
+           	}
+           }
+           
+           get_only_asset_name(asset_full_name) = name {
+           	# we are interested in the last part of the name, 
+           	# the rest is resource address
+           	split_name := split(asset_full_name, "/")
+           	last_index := count(split_name) - 1
+           	name := split_name[last_index]
+           }
+           
+           check_asset_and_return_its_rules(asset_type, naming_rules) = patterns {
+           	rule = naming_rules[_]
+           	rule.resource == asset_type
+           	patterns = rule.patterns
+           }
+           
+           no_name_match(asset_name, patterns) {
+           	not match_name(asset_name, patterns)
+           }
+           
+           match_name(name, patterns) {
+           	re_match(patterns[_], name)
+           }
+           #ENDINLINE

--- a/samples/gcp_enforce_naming.yaml
+++ b/samples/gcp_enforce_naming.yaml
@@ -1,0 +1,37 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPEnforceNamingConstraintV1
+metadata:
+  name: enforce_naming_convention
+spec:
+  severity: high
+  parameters:
+    # Provide naming patterns for each resource. You may provide more than one pattern per resource.
+    # All the resources that do not follow the naming requirements are alerted. 
+    # If you don't provide a rule for a resource, we simply ignore it. 
+    # Or if you don't provide any pattern, we again ignore.
+    naming_rules:
+      - resource: "compute.googleapis.com/SslCertificate" # asset_type field from inventory
+        patterns:
+          - "cert-sn-.*"
+          - "cert-self-signed-.*"
+      - resource: "compute.googleapis.com/Instance" # asset_type field from inventory
+        patterns:
+          - "^gcp-vm-(linux|windows)-v\\d+$"
+      - resource: "compute.googleapis.com/Firewall" # asset_type field from inventory
+        patterns:
+          - "^(gcp|gke)-firewall-(allow|deny)-(tcp|udp)-port-[\\d-]+$"
+          - "^(gcp|gke)-firewall-(allow|deny)-(all|icmp)$"

--- a/validator/gcp_enforce_naming.rego
+++ b/validator/gcp_enforce_naming.rego
@@ -1,0 +1,67 @@
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package templates.gcp.GCPEnforceNamingConstraintV1
+
+import data.validator.gcp.lib as lib
+
+###########################
+# Find Whitelist Violations
+###########################
+deny[{
+	"msg": message,
+	"details": metadata,
+}] {
+	constraint := input.constraint
+	lib.get_constraint_params(constraint, params)
+	asset := input.asset
+	naming_rules := lib.get_default(params, "naming_rules", [])
+	count(naming_rules) > 0 # make sure that we have some rules to validate
+
+	patterns := check_asset_and_return_its_rules(asset.asset_type, naming_rules)
+	name := get_only_asset_name(asset.name)
+	no_name_match(name, patterns)
+	trace(sprintf("no match name:%v, patterns:%v", [name, patterns]))
+
+	message := sprintf("%v does not obey the naming convention. Full address: %v", [name, asset.name])
+	metadata := {
+		"asset_name": name,
+		"asset_full_address": asset.name,
+		"patterns": patterns,
+	}
+}
+
+get_only_asset_name(asset_full_name) = name {
+	# we are interested in the last part of the name, 
+	# the rest is resource address
+	split_name := split(asset_full_name, "/")
+	last_index := count(split_name) - 1
+	name := split_name[last_index]
+}
+
+check_asset_and_return_its_rules(asset_type, naming_rules) = patterns {
+	rule = naming_rules[_]
+	rule.resource == asset_type
+	patterns = rule.patterns
+}
+
+no_name_match(asset_name, patterns) {
+	not match_name(asset_name, patterns)
+}
+
+match_name(name, patterns) {
+	re_match(patterns[_], name)
+}

--- a/validator/gcp_enforce_naming_test.rego
+++ b/validator/gcp_enforce_naming_test.rego
@@ -1,0 +1,76 @@
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package templates.gcp.GCPEnforceNamingConstraintV1
+
+import data.validator.gcp.lib as lib
+
+import data.test.fixtures.gcp_enforce_naming.assets as fixture_assets
+import data.test.fixtures.gcp_enforce_naming.constraints as fixture_constraints
+
+# Find all violations on our test cases
+find_violations[violation] {
+	asset := data.assets[_]
+	constraint := data.test_constraints
+
+	issues := deny with input.asset as asset
+		 with input.constraint as constraint
+
+	total_issues := count(issues)
+
+	violation := issues[_]
+}
+
+test_name_convention_all_match {
+	violations := find_violations with data.assets as fixture_assets
+		 with data.test_constraints as fixture_constraints.all_match
+
+	count(violations) == 0
+}
+
+test_name_convention_no_match {
+	violations := find_violations with data.assets as fixture_assets
+		 with data.test_constraints as fixture_constraints.partial_match
+
+	count(violations) > 0
+}
+
+test_get_only_asset_name {
+	"my_self_signed" == get_only_asset_name("//compute.googleapis.com/projects/test-project/global/sslCertificates/my_self_signed")
+	"" == get_only_asset_name("")
+}
+
+test_check_asset_and_return_its_rules {
+	lib.get_constraint_params(fixture_constraints.all_match, params)
+	naming_rules := lib.get_default(params, "naming_rules", [])
+	trace(sprintf("the naming rules %v", [naming_rules]))
+	patterns := check_asset_and_return_its_rules("compute.googleapis.com/SslCertificate", naming_rules)
+	is_array(patterns)
+	count(patterns) == 2
+}
+
+test_check_asset_and_return_its_rules_no_match {
+	lib.get_constraint_params(fixture_constraints.all_match, params)
+	naming_rules := lib.get_default(params, "naming_rules", [])
+	not check_asset_and_return_its_rules("compute.googleapis.com/ForwardingRules", naming_rules)
+	not check_asset_and_return_its_rules("compute.googleapis.com/ForwardingRules", [])
+}
+
+test_no_name_match {
+	not no_name_match("my-match-name", [".*"])
+	not no_name_match("my-match-name", ["my-match-.*", "nomatch"])
+	no_name_match("my-match-name", ["nomatch1", "nomatch2"])
+}

--- a/validator/test/fixtures/gcp_enforce_naming/assets/data.json
+++ b/validator/test/fixtures/gcp_enforce_naming/assets/data.json
@@ -1,0 +1,226 @@
+[
+  {
+    "name": "//compute.googleapis.com/projects/test-project/zones/us-east1-b/instances/vm-external-ip",
+    "asset_type": "compute.googleapis.com/Instance",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+      "discovery_name": "Instance",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/68478495408",
+      "data": {
+        "canIpForward": false,
+        "cpuPlatform": "Unknown CPU Platform",
+        "creationTimestamp": "2018-06-20T14:46:40.689-07:00",
+        "deletionProtection": false,
+        "description": "",
+        "disk": [
+          {
+            "autoDelete": true,
+            "boot": true,
+            "deviceName": "vm-external-ip",
+            "guestOsFeature": [
+              {
+                "type": "VIRTIO_SCSI_MULTIQUEUE"
+              }
+            ],
+            "index": 0,
+            "interface": "SCSI",
+            "license": [
+              "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/licenses/debian-9-stretch"
+            ],
+            "mode": "READ_WRITE",
+            "source": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-east1-b/disks/vm-external-ip",
+            "type": "PERSISTENT"
+          }
+        ],
+        "id": "108591614595134928",
+        "labelFingerprint": "42WmSpB8rSM=",
+        "machineType": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-east1-b/machineTypes/n1-standard-1",
+        "name": "vm-external-ip",
+        "networkInterfaces": [
+          {
+            "accessConfigs": [
+              {
+                "externalIp": "35.196.151.107",
+                "name": "external-nat",
+                "networkTier": "PREMIUM",
+                "type": "ONE_TO_ONE_NAT"
+              }
+            ],
+            "fingerprint": "FKYLBaTiCF0=",
+            "ipAddress": "10.142.0.2",
+            "name": "nic0",
+            "network": "https://www.googleapis.com/compute/v1/projects/test-project/global/networks/default",
+            "subnetwork": "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-east1/subnetworks/default"
+          }
+        ],
+        "scheduling": {
+          "automaticRestart": true,
+          "onHostMaintenance": "MIGRATE",
+          "preemptible": false
+        },
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-east1-b/instances/vm-external-ip",
+        "serviceAccount": [
+          {
+            "email": "77777777-compute@developer.gserviceaccount.com",
+            "scope": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          }
+        ],
+        "startRestricted": false,
+        "status": "TERMINATED",
+        "tags": {
+          "fingerprint": "42WmSpB8rSM="
+        },
+        "zone": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-east1-b"
+      }
+    }
+  },
+  {
+    "name": "//compute.googleapis.com/projects/test-project/zones/us-east1-b/instances/vm-external-ip-two",
+    "asset_type": "compute.googleapis.com/Instance",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+      "discovery_name": "Instance",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/68478495408",
+      "data": {
+        "canIpForward": false,
+        "cpuPlatform": "Unknown CPU Platform",
+        "creationTimestamp": "2018-06-20T14:46:40.689-07:00",
+        "deletionProtection": false,
+        "description": "",
+        "disk": [
+          {
+            "autoDelete": true,
+            "boot": true,
+            "deviceName": "vm-external-ip-two",
+            "guestOsFeature": [
+              {
+                "type": "VIRTIO_SCSI_MULTIQUEUE"
+              }
+            ],
+            "index": 0,
+            "interface": "SCSI",
+            "license": [
+              "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/licenses/debian-9-stretch"
+            ],
+            "mode": "READ_WRITE",
+            "source": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-east1-b/disks/vm-external-ip-two",
+            "type": "PERSISTENT"
+          }
+        ],
+        "id": "108591614595134928",
+        "labelFingerprint": "42WmSpB8rSM=",
+        "machineType": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-east1-b/machineTypes/n1-standard-1",
+        "name": "vm-external-ip",
+        "networkInterfaces": [
+          {
+            "accessConfigs": [
+              {
+                "externalIp": "35.196.151.110",
+                "name": "external-nat",
+                "networkTier": "PREMIUM",
+                "type": "ONE_TO_ONE_NAT"
+              }
+            ],
+            "fingerprint": "FKYLBaTiCF0=",
+            "ipAddress": "10.142.0.2",
+            "name": "nic0",
+            "network": "https://www.googleapis.com/compute/v1/projects/test-project/global/networks/default",
+            "subnetwork": "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-east1/subnetworks/default"
+          }
+        ],
+        "scheduling": {
+          "automaticRestart": true,
+          "onHostMaintenance": "MIGRATE",
+          "preemptible": false
+        },
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-east1-b/instances/vm-external-ip-two",
+        "serviceAccount": [
+          {
+            "email": "77777777-compute@developer.gserviceaccount.com",
+            "scope": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          }
+        ],
+        "startRestricted": false,
+        "status": "TERMINATED",
+        "tags": {
+          "fingerprint": "42WmSpB8rSM="
+        },
+        "zone": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-east1-b"
+      }
+    }
+  },
+  {
+    "name": "//compute.googleapis.com/projects/test-project/global/firewalls/gke-firewall-allow-all",
+    "asset_type": "compute.googleapis.com/Firewall",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+      "discovery_name": "Firewall",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/12345678",
+      "data": {
+        "allowed": [
+          {
+            "IPProtocol": "icmp",
+            "ipProtocol": "icmp"
+          },
+          {
+            "IPProtocol": "tcp",
+            "ipProtocol": "tcp",
+            "port": [
+              "1-65535"
+            ],
+            "ports": [
+              "1-65535"
+            ]
+          },
+          {
+            "IPProtocol": "udp",
+            "ipProtocol": "udp",
+            "port": [
+              "1-65535"
+            ],
+            "ports": [
+              "1-65535"
+            ]
+          }
+        ],
+        "creationTimestamp": "2019-09-11T14:22:52.101-07:00",
+        "description": "",
+        "direction": "INGRESS",
+        "disabled": false,
+        "id": "5433143896623602499",
+        "logConfig": {
+          "enable": false
+        },
+        "name": "gke-firewall-allow-all",
+        "network": "https://www.googleapis.com/compute/v1/projects/test-project/global/networks/gke-net",
+        "priority": 1000,
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/test-project/global/firewalls/gke-firewall-allow-all",
+        "sourceRange": [
+          "10.10.10.0/24"
+        ],
+        "sourceRanges": [
+          "10.10.10.0/24"
+        ],
+        "targetTag": [
+          "gke-node"
+        ],
+        "targetTags": [
+          "gke--node"
+        ]
+      }
+    },
+    "ancestors": [
+      "projects/12345667",
+      "folders/89101112",
+      "organizations/13141516"
+    ]
+  }
+ 
+]

--- a/validator/test/fixtures/gcp_enforce_naming/constraints/all_match/data.yaml
+++ b/validator/test/fixtures/gcp_enforce_naming/constraints/all_match/data.yaml
@@ -1,0 +1,33 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPEnforceNamingConstraintV1
+metadata:
+  name: enforce_naming_convention
+spec:
+  severity: high
+  parameters:
+    naming_rules:
+      - resource: "compute.googleapis.com/SslCertificate" # asset_type field from inventory
+        patterns:
+          - "cert-sn-.*"
+          - "cert-self-signed-.*"
+      - resource: "compute.googleapis.com/Instance" # asset_type field from inventory
+        patterns:
+          - "^vm-external-ip.*$"
+      - resource: "compute.googleapis.com/Firewall" # asset_type field from inventory
+        patterns:
+          - "^(gcp|gke)-firewall-(allow|deny)-(tcp|udp)-port-[\\d-]+$"
+          - "^(gcp|gke)-firewall-(allow|deny)-(all|icmp)$"

--- a/validator/test/fixtures/gcp_enforce_naming/constraints/partial_match/data.yaml
+++ b/validator/test/fixtures/gcp_enforce_naming/constraints/partial_match/data.yaml
@@ -1,0 +1,33 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPEnforceNamingConstraintV1
+metadata:
+  name: enforce_naming_convention
+spec:
+  severity: high
+  parameters:
+    naming_rules:
+      - resource: "compute.googleapis.com/SslCertificate" # asset_type field from inventory
+        patterns:
+          - "cert-sn-.*"
+          - "cert-self-signed-.*"
+      - resource: "compute.googleapis.com/Instance" # asset_type field from inventory
+        patterns:
+          - "^vm-external-ip$"
+      - resource: "compute.googleapis.com/Firewall" # asset_type field from inventory
+        patterns:
+          - "^(gcp|gke)-firewall-(allow|deny)-(tcp|udp)-port-[\\d-]+$"
+          - "^(gcp|gke)-firewall-(allow|deny)-(all|icmp)$"


### PR DESCRIPTION
Enables security teams to create naming policies for the resources. For each resource, you are able to define different and multiple naming patterns

 