### PR TITLE
[BLOCKED] CIS 7: GKE Disable Alpha

### DIFF
--- a/policies/templates/gcp_gke_disable_alpha_v1.yaml
+++ b/policies/templates/gcp_gke_disable_alpha_v1.yaml
@@ -1,0 +1,65 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: templates.gatekeeper.sh/v1alpha1
+kind: ConstraintTemplate
+metadata:
+  name: gcp-gke-disable-alpha-v1
+spec:
+  crd:
+    spec:
+      names:
+        kind: GCPGKEDisableAlphaConstraintV1
+        plural: gcpgkedisablealphaconstraintsv1
+      validation:
+        openAPIV3Schema:
+          properties: {}
+  targets:
+    validation.gcp.forsetisecurity.org:
+      rego: | #INLINE("validator/gke_disable_alpha.rego")
+             #
+             # Copyright 2019 Google LLC
+             #
+             # Licensed under the Apache License, Version 2.0 (the "License");
+             # you may not use this file except in compliance with the License.
+             # You may obtain a copy of the License at
+             #
+             #      http://www.apache.org/licenses/LICENSE-2.0
+             #
+             # Unless required by applicable law or agreed to in writing, software
+             # distributed under the License is distributed on an "AS IS" BASIS,
+             # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+             # See the License for the specific language governing permissions and
+             # limitations under the License.
+             #
+             
+             package templates.gcp.GCPGKEDisableAlphaConstraintV1
+             
+             import data.validator.gcp.lib as lib
+             
+             deny[{
+             	"msg": message,
+             	"details": metadata,
+             }] {
+             	constraint := input.constraint
+             	asset := input.asset
+             	asset.asset_type == "container.googleapis.com/Cluster"
+             
+             	cluster := asset.resource.data
+             	lib.get_default(cluster, "enableKubernetesAlpha", false) == true
+             	message := sprintf("Kubernetes alpha enabled in cluster %v.", [asset.name])
+             	metadata := {"resource": asset.name}
+             }
+             #ENDINLINE

--- a/samples/gke_disable_alpha.yaml
+++ b/samples/gke_disable_alpha.yaml
@@ -1,0 +1,24 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPGKEDisableAlphaConstraintV1
+metadata:
+  name: gke_disable_alpha
+spec:
+  severity: high
+  match:
+    gcp:
+      target: ["organization/*"]
+  parameters: {}

--- a/validator/gke_disable_alpha.rego
+++ b/validator/gke_disable_alpha.rego
@@ -1,0 +1,33 @@
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package templates.gcp.GCPGKEDisableAlphaConstraintV1
+
+import data.validator.gcp.lib as lib
+
+deny[{
+	"msg": message,
+	"details": metadata,
+}] {
+	constraint := input.constraint
+	asset := input.asset
+	asset.asset_type == "container.googleapis.com/Cluster"
+
+	cluster := asset.resource.data
+	lib.get_default(cluster, "enableKubernetesAlpha", false) == true
+	message := sprintf("Kubernetes alpha enabled in cluster %v.", [asset.name])
+	metadata := {"resource": asset.name}
+}

--- a/validator/gke_disable_alpha_test.rego
+++ b/validator/gke_disable_alpha_test.rego
@@ -1,0 +1,34 @@
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package templates.gcp.GCPGKEDisableAlphaConstraintV1
+
+import data.validator.gcp.lib as lib
+
+all_violations[violation] {
+	resource := data.test.fixtures.gke_disable_alpha.assets[_]
+	constraint := data.test.fixtures.gke_disable_alpha.constraints
+
+	issues := deny with input.asset as resource
+		 with input.constraint as constraint
+
+	violation := issues[_]
+}
+
+test_violations_basic {
+	violation_resources := {r | r = all_violations[_].details.resource}
+	violation_resources == {"//container.googleapis.com/projects/transfer-repos/zones/us-central1-c/clusters/bad"}
+}

--- a/validator/test/fixtures/gke_disable_alpha/assets/data.json
+++ b/validator/test/fixtures/gke_disable_alpha/assets/data.json
@@ -1,0 +1,161 @@
+[
+    {
+        "name": "//container.googleapis.com/projects/transfer-repos/zones/us-central1-c/clusters/good",
+        "asset_type": "container.googleapis.com/Cluster",
+        "resource": {
+          "version": "v1",
+          "discovery_document_uri": "https://container.googleapis.com/$discovery/rest",
+          "discovery_name": "Cluster",
+          "parent": "//cloudresourcemanager.googleapis.com/projects/282148707733",
+          "data": {
+            "addonsConfig": {
+              "networkPolicyConfig": {
+                "disabled": true
+              }
+            },
+            "clusterIpv4Cidr": "10.44.0.0/14",
+            "createTime": "2016-11-19T05:58:02+00:00",
+            "currentMasterVersion": "1.10.11-gke.1",
+            "currentNodeCount": 4,
+            "currentNodeVersion": "1.4.6",
+            "endpoint": "104.196.229.72",
+            "initialClusterVersion": "1.4.6",
+            "enableKubernetesAlpha": false,
+            "instanceGroupUrls": [
+              "https://www.googleapis.com/compute/v1/projects/pso-cicd8/zones/us-west1-b/instanceGroupManagers/gke-canary-west-default-pool-496ebc1d-grp"
+            ],
+            "legacyAbac": {
+              "enabled": true
+            },
+            "location": "us-west1-b",
+            "locations": [
+              "us-west1-b"
+            ],
+            "loggingService": "logging.googleapis.com",
+            "monitoringService": "monitoring.googleapis.com",
+            "name": "canary-west",
+            "network": "default",
+            "networkConfig": {
+              "network": "projects/pso-cicd8/global/networks/default",
+              "subnetwork": "projects/pso-cicd8/regions/us-west1/subnetworks/default"
+            },
+            "nodeIpv4CidrSize": 24,
+            "nodePools": [
+              {
+                "autoscaling": {},
+                "config": {
+                  "diskSizeGb": 100,
+                  "imageType": "COS",
+                  "machineType": "n1-standard-1",
+                  "oauthScopes": [
+                    "https://www.googleapis.com/auth/compute",
+                    "https://www.googleapis.com/auth/devstorage.read_only",
+                    "https://www.googleapis.com/auth/logging.write",
+                    "https://www.googleapis.com/auth/servicecontrol",
+                    "https://www.googleapis.com/auth/service.management.readonly",
+                    "https://www.googleapis.com/auth/trace.append"
+                  ],
+                  "serviceAccount": "default"
+                },
+                "initialNodeCount": 2,
+                "instanceGroupUrls": [
+                  "https://www.googleapis.com/compute/v1/projects/pso-cicd8/zones/us-west1-b/instanceGroupManagers/gke-canary-west-default-pool-496ebc1d-grp"
+                ],
+                "management": {
+                  "autoUpgrade": "true"
+                },
+                "name": "default-pool",
+                "selfLink": "https://container.googleapis.com/v1/projects/pso-cicd8/zones/us-west1-b/clusters/canary-west/nodePools/default-pool",
+                "status": "RUNNING",
+                "version": "1.4.6"
+              }
+            ],
+            "selfLink": "https://container.googleapis.com/v1/projects/pso-cicd8/zones/us-west1-b/clusters/canary-west",
+            "servicesIpv4Cidr": "10.47.240.0/20",
+            "status": "RUNNING",
+            "subnetwork": "default",
+            "zone": "us-west1-b"
+          }
+        }
+      },
+      {
+        "name": "//container.googleapis.com/projects/transfer-repos/zones/us-central1-c/clusters/bad",
+        "asset_type": "container.googleapis.com/Cluster",
+        "resource": {
+          "version": "v1",
+          "discovery_document_uri": "https://container.googleapis.com/$discovery/rest",
+          "discovery_name": "Cluster",
+          "parent": "//cloudresourcemanager.googleapis.com/projects/282148707733",
+          "data": {
+            "addonsConfig": {
+              "networkPolicyConfig": {
+                "disabled": true
+              }
+            },
+            "clusterIpv4Cidr": "10.44.0.0/14",
+            "createTime": "2016-11-19T05:58:02+00:00",
+            "currentMasterVersion": "1.10.11-gke.1",
+            "currentNodeCount": 4,
+            "currentNodeVersion": "1.4.6",
+            "enableKubernetesAlpha": true,
+            "endpoint": "104.196.229.72",
+            "initialClusterVersion": "1.4.6",
+            "instanceGroupUrls": [
+              "https://www.googleapis.com/compute/v1/projects/pso-cicd8/zones/us-west1-b/instanceGroupManagers/gke-canary-west-default-pool-496ebc1d-grp"
+            ],
+            "legacyAbac": {
+              "enabled": true
+            },
+            "location": "us-west1-b",
+            "locations": [
+              "us-west1-b"
+            ],
+            "loggingService": "logging.googleapis.com/kubernetes",
+            "monitoringService": "none",
+            "name": "canary-west",
+            "network": "default",
+            "networkConfig": {
+              "network": "projects/pso-cicd8/global/networks/default",
+              "subnetwork": "projects/pso-cicd8/regions/us-west1/subnetworks/default"
+            },
+            "nodeIpv4CidrSize": 24,
+            "nodePools": [
+              {
+                "autoscaling": {},
+                "config": {
+                  "diskSizeGb": 100,
+                  "imageType": "COS",
+                  "machineType": "n1-standard-1",
+                  "oauthScopes": [
+                    "https://www.googleapis.com/auth/compute",
+                    "https://www.googleapis.com/auth/devstorage.read_only",
+                    "https://www.googleapis.com/auth/logging.write",
+                    "https://www.googleapis.com/auth/servicecontrol",
+                    "https://www.googleapis.com/auth/service.management.readonly",
+                    "https://www.googleapis.com/auth/trace.append"
+                  ],
+                  "serviceAccount": "default"
+                },
+                "initialNodeCount": 2,
+                "instanceGroupUrls": [
+                  "https://www.googleapis.com/compute/v1/projects/pso-cicd8/zones/us-west1-b/instanceGroupManagers/gke-canary-west-default-pool-496ebc1d-grp"
+                ],
+                "management": {
+                  "autoUpgrade": "true"
+                },
+                "name": "default-pool",
+                "selfLink": "https://container.googleapis.com/v1/projects/pso-cicd8/zones/us-west1-b/clusters/canary-west/nodePools/default-pool",
+                "status": "RUNNING",
+                "version": "1.4.6"
+              }
+            ],
+            "selfLink": "https://container.googleapis.com/v1/projects/pso-cicd8/zones/us-west1-b/clusters/canary-west",
+            "servicesIpv4Cidr": "10.47.240.0/20",
+            "status": "RUNNING",
+            "subnetwork": "default",
+            "zone": "us-west1-b"
+          }
+        }
+      }
+    ]
+    

--- a/validator/test/fixtures/gke_disable_alpha/constraints/data.yaml
+++ b/validator/test/fixtures/gke_disable_alpha/constraints/data.yaml
@@ -1,0 +1,24 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPGKEDisableAlphaConstraintV1
+metadata:
+  name: gke_disable_alpha
+spec:
+  severity: high
+  match:
+    gcp:
+      target: ["organization/*"]
+  parameters: {}


### PR DESCRIPTION
CAI does not currently export this field, but I am using the field name listed in the [API docs](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#resource-cluster) (`enableKubernetesAlpha`) and this should work as soon as CAI adds that field.