### PR TITLE
Remove unused field.

### DIFF
--- a/policies/templates/gcp_allowed_resource_types_v1.yaml
+++ b/policies/templates/gcp_allowed_resource_types_v1.yaml
@@ -27,7 +27,6 @@ spec:
     spec:
       names:
         kind: GCPAllowedResourceTypesConstraintV1
-        plural: gcpallowedresourcetypesconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_always_violates_v1.yaml
+++ b/policies/templates/gcp_always_violates_v1.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPAlwaysViolatesConstraintV1
-        plural: gcpalwaysviolatesconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_app_service_versions.yaml
+++ b/policies/templates/gcp_app_service_versions.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPAppEngineServiceVersionsConstraintV1
-        plural: gcpappengineserviceversionsconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_appengine_location_v1.yaml
+++ b/policies/templates/gcp_appengine_location_v1.yaml
@@ -26,7 +26,6 @@ spec:
     spec:
       names:
         kind: GCPAppengineLocationConstraintV1
-        plural: gcpappenginelocationconstraintv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_bigquery_cmek_encryption_v1.yaml
+++ b/policies/templates/gcp_bigquery_cmek_encryption_v1.yaml
@@ -24,7 +24,6 @@ spec:
     spec:
       names:
         kind: GCPBigQueryCMEKEncryptionConstraintV1
-        plural: gcpbigquerycmekencryptionconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_bigquery_dataset_world_readable_v1.yaml
+++ b/policies/templates/gcp_bigquery_dataset_world_readable_v1.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPBigQueryDatasetWorldReadableConstraintV1
-        plural: gcpbiquerydatasetworldreadableconstraintv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_bq_dataset_location_v1.yaml
+++ b/policies/templates/gcp_bq_dataset_location_v1.yaml
@@ -27,7 +27,6 @@ spec:
     spec:
       names:
         kind: GCPBigQueryDatasetLocationConstraintV1
-        plural: gcpbigquerydatasetlocationconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_cmek_rotation_v1.yaml
+++ b/policies/templates/gcp_cmek_rotation_v1.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPCMEKRotationConstraintV1
-        plural: gcpcmekrotationconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_cmek_settings_v1.yaml
+++ b/policies/templates/gcp_cmek_settings_v1.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPCMEKSettingsConstraintV1
-        plural: gcpcmeksettingsconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_compute_external_ip_access_v1.yaml
+++ b/policies/templates/gcp_compute_external_ip_access_v1.yaml
@@ -24,7 +24,6 @@ spec:
     spec:
       names:
         kind: GCPComputeExternalIpAccessConstraintV1
-        plural: gcpcomputeexternalipaccessconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_compute_ip_forward_v1.yaml
+++ b/policies/templates/gcp_compute_ip_forward_v1.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPComputeIpForwardConstraintV1
-        plural: gcpcomputeipforwardconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_compute_network_interface_whitelist_v1.yaml
+++ b/policies/templates/gcp_compute_network_interface_whitelist_v1.yaml
@@ -23,7 +23,6 @@ spec:
     spec:
       names:
         kind: GCPComputeNetworkInterfaceWhitelistConstraintV1
-        plural: gcpcomputenetworkinterfacewhitelistconstraintsV1
       validation:
         openAPIV3Schema:
             whitelist:

--- a/policies/templates/gcp_compute_zone_v1.yaml
+++ b/policies/templates/gcp_compute_zone_v1.yaml
@@ -28,7 +28,6 @@ spec:
     spec:
       names:
         kind: GCPComputeZoneConstraintV1
-        plural: gcpcomputezoneconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_dataproc_location_v1.yaml
+++ b/policies/templates/gcp_dataproc_location_v1.yaml
@@ -26,7 +26,6 @@ spec:
     spec:
       names:
         kind: GCPDataprocLocationConstraintV1
-        plural: gcpdataproclocationconstraintv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_dnssec_prevent_rsasha1_v1.yaml
+++ b/policies/templates/gcp_dnssec_prevent_rsasha1_v1.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPDNSSECPreventRSASHA1ConstraintV1
-        plural: gcpdnssecpreventrsasha1constraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_dnssec_v1.yaml
+++ b/policies/templates/gcp_dnssec_v1.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPDNSSECConstraintV1
-        plural: gcpdnssecconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_enforce_labels_v1.yaml
+++ b/policies/templates/gcp_enforce_labels_v1.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPEnforceLabelConstraintV1
-        plural: gcpenforcelabelconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_enforce_naming_v1.yaml
+++ b/policies/templates/gcp_enforce_naming_v1.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPEnforceNamingConstraintV1
-        plural: gcpenforcenamingconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_gke_allowed_node_sa_v1.yaml
+++ b/policies/templates/gcp_gke_allowed_node_sa_v1.yaml
@@ -23,7 +23,6 @@ spec:
     spec:
       names:
         kind: GCPGKEAllowedNodeSAConstraintV1
-        plural: gcpgkeallowedodesaconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_gke_cluster_location_v1.yaml
+++ b/policies/templates/gcp_gke_cluster_location_v1.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GKEClusterLocationConstraintV1
-        plural: gkeclusterlocationconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_gke_container_optimized_os.yaml
+++ b/policies/templates/gcp_gke_container_optimized_os.yaml
@@ -24,7 +24,6 @@ spec:
     spec:
       names:
         kind: GCPGKEContainerOptimizedOSConstraintV1
-        plural: gcpgkecontaineroptimizedosconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_gke_dashboard_v1.yaml
+++ b/policies/templates/gcp_gke_dashboard_v1.yaml
@@ -23,7 +23,6 @@ spec:
     spec:
       names:
         kind: GCPGKEDashboardConstraintV1
-        plural: gcpgkedashboardconstraintsv1        
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_gke_disable_default_service_account_v1.yaml
+++ b/policies/templates/gcp_gke_disable_default_service_account_v1.yaml
@@ -23,7 +23,6 @@ spec:
     spec:
       names:
         kind: GCPGKEDisableDefaultServiceAccountConstraintV1
-        plural: gcpgkedisabledefaultserviceaccountconstraintsV1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_gke_disable_legacy_endpoints_v1.yaml
+++ b/policies/templates/gcp_gke_disable_legacy_endpoints_v1.yaml
@@ -24,7 +24,6 @@ spec:
     spec:
       names:
         kind: GCPGKEDisableLegacyEndpointsConstraintV1
-        plural: gcpgkedisablelegacyendpointsconstraintsV1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_gke_enable_alias_ip_ranges.yaml
+++ b/policies/templates/gcp_gke_enable_alias_ip_ranges.yaml
@@ -24,7 +24,6 @@ spec:
     spec:
       names:
         kind: GCPGKEEnableAliasIPRangesConstraintV1
-        plural: gcpgkeenablealiasiprangesconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_gke_enable_stackdriver_kubernetes_engine_monitoring_v1.yaml
+++ b/policies/templates/gcp_gke_enable_stackdriver_kubernetes_engine_monitoring_v1.yaml
@@ -24,7 +24,6 @@ spec:
     spec:
       names:
         kind: GCPGKEEnableStackdriverKubernetesEngineMonitoringConstraintV1
-        plural: gcpgkeenablestackdriverkubernetesenginemonitoringconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_gke_enable_stackdriver_logging_v1.yaml
+++ b/policies/templates/gcp_gke_enable_stackdriver_logging_v1.yaml
@@ -24,7 +24,6 @@ spec:
     spec:
       names:
         kind: GCPGKEEnableStackdriverLoggingConstraintV1
-        plural: gcpgkeenablestackdriverloggingconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_gke_enable_stackdriver_monitoring_v1.yaml
+++ b/policies/templates/gcp_gke_enable_stackdriver_monitoring_v1.yaml
@@ -24,7 +24,6 @@ spec:
     spec:
       names:
         kind: GCPGKEEnableStackdriverMonitoringConstraintV1
-        plural: gcpgkeenablestackdrivermonitoringconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_gke_legacy_abac_v1.yaml
+++ b/policies/templates/gcp_gke_legacy_abac_v1.yaml
@@ -23,7 +23,6 @@ spec:
     spec:
       names:
         kind: GCPGKELegacyAbacConstraintV1
-        plural: gcpgkelegacyabacconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_gke_master_authorized_networks_enabled_v1.yaml
+++ b/policies/templates/gcp_gke_master_authorized_networks_enabled_v1.yaml
@@ -24,7 +24,6 @@ spec:
     spec:
       names:
         kind: GCPGKEMasterAuthorizedNetworksEnabledConstraintV1
-        plural: gcpgkemasterauthorizednetworksenabledconstraintv1        
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_gke_node_auto_repair_v1.yaml
+++ b/policies/templates/gcp_gke_node_auto_repair_v1.yaml
@@ -24,7 +24,6 @@ spec:
     spec:
       names:
         kind: GCPGKENodeAutoRepairConstraintV1
-        plural: gcpgkenodeautorepairconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_gke_node_auto_upgrade_v1.yaml
+++ b/policies/templates/gcp_gke_node_auto_upgrade_v1.yaml
@@ -24,7 +24,6 @@ spec:
     spec:
       names:
         kind: GCPGKENodeAutoUpgradeConstraintV1
-        plural: gcpgkenodeautoupgradeconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_gke_private_cluster_v1.yaml
+++ b/policies/templates/gcp_gke_private_cluster_v1.yaml
@@ -24,7 +24,6 @@ spec:
     spec:
       names:
         kind: GCPGKEPrivateClusterConstraintV1
-        plural: gcpgkeprivateclusterconstraintsv1        
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_gke_restrict_client_auth_methods_v1.yaml
+++ b/policies/templates/gcp_gke_restrict_client_auth_methods_v1.yaml
@@ -24,7 +24,6 @@ spec:
     spec:
       names:
         kind: GCPGKERestrictClientAuthenticationMethodsConstraintV1
-        plural: gcpgkerestrictclientauthenticationmethodsconstraintsV1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_gke_restrict_pod_traffic_v1.yaml
+++ b/policies/templates/gcp_gke_restrict_pod_traffic_v1.yaml
@@ -23,7 +23,6 @@ spec:
     spec:
       names:
         kind: GCPGKERestrictPodTrafficConstraintV1
-        plural: gcpgkerestrictpodtrafficconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_glb_external_ip_access_constraint_v1.yaml
+++ b/policies/templates/gcp_glb_external_ip_access_constraint_v1.yaml
@@ -23,7 +23,6 @@ spec:
     spec:
       names:
         kind: GCPGLBExternalIpAccessConstraintV1
-        plural: gcpglbexternalipaccessconstraintv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_iam_allow_ban_roles_v1.yaml
+++ b/policies/templates/gcp_iam_allow_ban_roles_v1.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPIAMAllowBanRolesConstraintV1
-        plural: gcpiamallowbanrolesconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_iam_allowed_bindings_v1.yaml
+++ b/policies/templates/gcp_iam_allowed_bindings_v1.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPIAMAllowedBindingsConstraintV1
-        plural: gcpiamallowedbindingsconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_iam_allowed_policy_member_domains.yaml
+++ b/policies/templates/gcp_iam_allowed_policy_member_domains.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPIAMAllowedPolicyMemberDomainsConstraintV1
-        plural: gcpiamallowedpolicymemberdomainsconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_iam_audit_log.yaml
+++ b/policies/templates/gcp_iam_audit_log.yaml
@@ -24,7 +24,6 @@ spec:
     spec:
       names:
         kind: GCPIAMAuditLogConstraintV1
-        plural: gcpiamauditlogconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_iam_restrict_service_account_creation_v1.yaml
+++ b/policies/templates/gcp_iam_restrict_service_account_creation_v1.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPIAMRestrictServiceAccountCreationConstraintV1
-        plural: gcpiamrestrictserviceaccountcreationconstraintv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_iam_restrict_service_account_key_type_v1.yaml
+++ b/policies/templates/gcp_iam_restrict_service_account_key_type_v1.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPIAMRestrictServiceAccountKeyTypeConstraintV1
-        plural: gcpiamrestrictserviceaccountkeytypeconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_lb_forwarding_rules_whitelist.yaml
+++ b/policies/templates/gcp_lb_forwarding_rules_whitelist.yaml
@@ -23,7 +23,6 @@ spec:
     spec:
       names:
         kind: GCPLBForwardingRuleWhitelistConstraintV1
-        plural: gcplbforwardingrulewhitelistconstraintsv1
       validation:
         openAPIV3Schema:
           whitelist:

--- a/policies/templates/gcp_network_enable_firewall_logs_v1.yaml
+++ b/policies/templates/gcp_network_enable_firewall_logs_v1.yaml
@@ -24,7 +24,6 @@ spec:
     spec:
       names:
         kind: GCPNetworkEnableFirewallLogsConstraintV1
-        plural: gcpnetworkenablefirewalllogsconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_network_enable_flow_logs_v1.yaml
+++ b/policies/templates/gcp_network_enable_flow_logs_v1.yaml
@@ -24,7 +24,6 @@ spec:
     spec:
       names:
         kind: GCPNetworkEnableFlowLogsConstraintV1
-        plural: gcpnetworkenableflowlogsconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_network_enable_private_google_access_v1.yaml
+++ b/policies/templates/gcp_network_enable_private_google_access_v1.yaml
@@ -24,7 +24,6 @@ spec:
     spec:
       names:
         kind: GCPNetworkEnablePrivateGoogleAccessConstraintV1
-        plural: gcpnetworkenableprivategoogleaccessconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_network_routing_v1.yaml
+++ b/policies/templates/gcp_network_routing_v1.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPNetworkRoutingConstraintV1
-        plural: gcpnetworkroutingconstraintsv1
       validation:
         openAPIV3Schema:
           mode:

--- a/policies/templates/gcp_restricted_firewall_rules_v1.yaml
+++ b/policies/templates/gcp_restricted_firewall_rules_v1.yaml
@@ -29,7 +29,6 @@ spec:
     spec:
       names:
         kind: GCPRestrictedFirewallRulesConstraintV1
-        plural: gcprestrictedfirewallrulesconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_serviceusage_allowed_services_v1.yaml
+++ b/policies/templates/gcp_serviceusage_allowed_services_v1.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPServiceUsageConstraintV1
-        plural: gcpserviceusageconstraintsV1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_spanner_location_v1.yaml
+++ b/policies/templates/gcp_spanner_location_v1.yaml
@@ -26,7 +26,6 @@ spec:
     spec:
       names:
         kind: GCPSpannerLocationConstraintV1
-        plural: gcpspannerlocationconstraintv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_sql_allowed_authorized_networks_v1.yaml
+++ b/policies/templates/gcp_sql_allowed_authorized_networks_v1.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPSQLAllowedAuthorizedNetworksConstraintV1
-        plural: gcpsqlallowedauthorizednetworksconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_sql_backup_v1.yaml
+++ b/policies/templates/gcp_sql_backup_v1.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPSQLBackupConstraintV1
-        plural: gcpsqlBackupconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_sql_location_v1.yaml
+++ b/policies/templates/gcp_sql_location_v1.yaml
@@ -28,7 +28,6 @@ spec:
     spec:
       names:
         kind: GCPSQLLocationConstraintV1
-        plural: gcpsqllocationconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_sql_maintenance_window_v1.yaml
+++ b/policies/templates/gcp_sql_maintenance_window_v1.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPSQLMaintenanceWindowConstraintV1
-        plural: gcpsqlmaintenancewindowconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_sql_public_ip_v1.yaml
+++ b/policies/templates/gcp_sql_public_ip_v1.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPSQLPublicIpConstraintV1
-        plural: gcpsqlpublicipconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_sql_ssl_v1.yaml
+++ b/policies/templates/gcp_sql_ssl_v1.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPSQLSSLConstraintV1
-        plural: gcpsqlsslconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_storage_bucket_policy_only_v1.yaml
+++ b/policies/templates/gcp_storage_bucket_policy_only_v1.yaml
@@ -30,7 +30,6 @@ spec:
     spec:
       names:
         kind: GCPStorageBucketPolicyOnlyConstraintV1
-        plural: gcpstoragebucketpolicyonlyconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_storage_bucket_world_readable_v1.yaml
+++ b/policies/templates/gcp_storage_bucket_world_readable_v1.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPStorageBucketWorldReadableConstraintV1
-        plural: gcpstoragebucketworldreadableconstraintv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_storage_cmek_encryption_v1.yaml
+++ b/policies/templates/gcp_storage_cmek_encryption_v1.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPStorageCMEKEncryptionConstraintV1
-        plural: gcpstoragecmekencryptionconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_storage_location_v1.yaml
+++ b/policies/templates/gcp_storage_location_v1.yaml
@@ -28,7 +28,6 @@ spec:
     spec:
       names:
         kind: GCPStorageLocationConstraintV1
-        plural: gcpstoragelocationconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_storage_logging_v1.yaml
+++ b/policies/templates/gcp_storage_logging_v1.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPStorageLoggingConstraintV1
-        plural: gcpstorageloggingconstraintsv1
       validation:
         openAPIV3Schema:
           properties: {}

--- a/policies/templates/gcp_vpc_sc_ensure_access_levels_v1.yaml
+++ b/policies/templates/gcp_vpc_sc_ensure_access_levels_v1.yaml
@@ -22,7 +22,6 @@ spec:
     spec:
       names:
         kind: GCPVPCSCEnsureAccessLevelsConstraintV1
-        plural: gcpvpcscensureaccesslevelsconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_vpc_sc_ensure_project_v1.yaml
+++ b/policies/templates/gcp_vpc_sc_ensure_project_v1.yaml
@@ -22,7 +22,6 @@ spec:
     spec:
       names:
         kind: GCPVPCSCEnsureProjectConstraintV1
-        plural: gcpvpcscensureprojectconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_vpc_sc_ensure_services_v1.yaml
+++ b/policies/templates/gcp_vpc_sc_ensure_services_v1.yaml
@@ -22,7 +22,6 @@ spec:
     spec:
       names:
         kind: GCPVPCSCEnsureServicesConstraintV1
-        plural: gcpvpcscensureservicesconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_vpc_sc_ip_range_v1.yaml
+++ b/policies/templates/gcp_vpc_sc_ip_range_v1.yaml
@@ -22,7 +22,6 @@ spec:
     spec:
       names:
         kind: GCPVPCSCIPRangeConstraintV1
-        plural: gcpvpcsciprangeconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_vpc_sc_project_perimeter_v1.yaml
+++ b/policies/templates/gcp_vpc_sc_project_perimeter_v1.yaml
@@ -22,7 +22,6 @@ spec:
     spec:
       names:
         kind: GCPVPCSCProjectPerimeterConstraintV1
-        plural: gcpvpcscprojectperimeterconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_vpc_sc_whitelist_regions_v1.yaml
+++ b/policies/templates/gcp_vpc_sc_whitelist_regions_v1.yaml
@@ -22,7 +22,6 @@ spec:
     spec:
       names:
         kind: GCPVPCSCWhitelistRegionsConstraintV1
-        plural: gcpvpcscwhitelistregionsconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/legacy/gcp_external_ip_access_v1.yaml
+++ b/policies/templates/legacy/gcp_external_ip_access_v1.yaml
@@ -24,7 +24,6 @@ spec:
     spec:
       names:
         kind: GCPExternalIpAccessConstraintV1
-        plural: gcpexternalipaccessconstraintsv1
       validation:
         openAPIV3Schema:
           properties:


### PR DESCRIPTION
spec.crd.names.plural was never used actually used by ConfigValidator or
Constraint Framework.  We can remove this field from the CTs.