### PR TITLE
Fix some constraint templates

### DIFF
--- a/policies/templates/gcp_app_service_versions.yaml
+++ b/policies/templates/gcp_app_service_versions.yaml
@@ -28,7 +28,6 @@ spec:
               type: integer
               description: "The maxinum number of simultaneous versions
                Defaults to 2"
-              default: 2
   targets:
    validation.gcp.forsetisecurity.org:
       rego: | #INLINE("validator/app_service_versions.rego")

--- a/policies/templates/gcp_compute_ip_forward_v1.yaml
+++ b/policies/templates/gcp_compute_ip_forward_v1.yaml
@@ -28,11 +28,9 @@ spec:
               type: string
               enum: [blacklist, whitelist]
               description: "If whitelist, IP forwarding will only be allowed on specified instances. If blacklist, IP forwarding will be allowed except on specified instances."
-              default: "whitelist"
             match_mode:
               type: string
               enum: [exact, regex]
-              default: "exact"
               description: "Whether to use exact string matching or regular expressions against instance names"
             instances:
               type: array

--- a/policies/templates/gcp_enforce_labels_v1.yaml
+++ b/policies/templates/gcp_enforce_labels_v1.yaml
@@ -23,6 +23,7 @@ spec:
         kind: GCPEnforceLabelConstraintV1
       validation:
         openAPIV3Schema:
+          required: ["mandatory_labels"]
           properties:
             mandatory_labels:
               description: |
@@ -58,7 +59,6 @@ spec:
                 "
               type: array
               items: string
-            required: ["mandatory_labels"]
   targets:
     validation.gcp.forsetisecurity.org:
       rego: | #INLINE("validator/enforce_labels.rego")

--- a/policies/templates/gcp_gke_enable_stackdriver_kubernetes_engine_monitoring_v1.yaml
+++ b/policies/templates/gcp_gke_enable_stackdriver_kubernetes_engine_monitoring_v1.yaml
@@ -23,7 +23,7 @@ spec:
   crd:
     spec:
       names:
-        kind: GCPGKEEnableStackdriverKubernetesEngineMonitoringConstraintV1
+        kind: GCPGKEEnableStackdriverKubernetesEngineMonitoringV1
       validation:
         openAPIV3Schema:
           properties: {}
@@ -46,7 +46,7 @@ spec:
             # limitations under the License.
             #
             
-            package templates.gcp.GCPGKEEnableStackdriverKubernetesEngineMonitoringConstraintV1
+            package templates.gcp.GCPGKEEnableStackdriverKubernetesEngineMonitoringV1
             
             import data.validator.gcp.lib as lib
             

--- a/policies/templates/gcp_restricted_firewall_rules_v1.yaml
+++ b/policies/templates/gcp_restricted_firewall_rules_v1.yaml
@@ -42,12 +42,10 @@ spec:
                     description: "Direction of the rules to restrict."
                     type: string
                     enum: ["INGRESS", "EGRESS", "any"]
-                    default: "any"
                   rule_type:
                     description: "Type of the rules to restrict."
                     type: string
                     enum: ["allowed", "denied", "any"]
-                    default: "any"
                   port:
                     description: |
                       "Port of the rules to restrict. This parameter is tighly coupled with the
@@ -62,7 +60,6 @@ spec:
                                     determine if the FW rule is restricted
                           * 'all' (if the rule matches all ports for a given protocol)"
                     type: string
-                    default: "any"
                   protocol:
                     description: |
                       "Protocol of the rules to restrict. This parameter is tighly coupled with
@@ -74,7 +71,6 @@ spec:
                                     to determine if the FW rule is restricted
                           * 'all' (if the rule matches all protocols)"
                     type: string
-                    default: "any"
                   source_ranges:
                     description: |
                       "Source ranges of the rules to restrict. A fw rule only matches if ONE of its
@@ -88,7 +84,6 @@ spec:
                                   in the restricted FW rule"
                     type: array
                     items: string
-                    default: ['any']
                   source_tags:
                     description: |
                       "Source tags of the rules to restrict. A fw rule only matches if ONE of its source
@@ -101,7 +96,6 @@ spec:
                                   in the restricted FW rule"
                     type: array
                     items: string
-                    default: ['any']
                   source_service_accounts:
                     description: |
                       "Source service accounts of the rules to restrict. A fw rule only matches if ONE of
@@ -115,7 +109,6 @@ spec:
                                   service account existsin the restricted FW rule"
                     type: array
                     items: string
-                    default: ['any']
                   target_ranges:
                     description: |
                       "Target (or destination) ranges of the rules to restrict. A fw rule only matches
@@ -129,7 +122,6 @@ spec:
                                   range exists in the restricted FW rule"
                     type: array
                     items: string
-                    default: ['any']
                   target_tags:
                     description: |
                       "Target tags of the rules to restrict. A fw rule only matches if ONE of its target
@@ -142,7 +134,6 @@ spec:
                                   in the restricted FW rule"
                     type: array
                     items: string
-                    default: ['any']
                   target_service_accounts:
                     description: |
                       "Target service accounts of the rules to restrict. A fw rule only matches if ONE of
@@ -156,12 +147,10 @@ spec:
                                   service account exists in the restricted FW rule"
                     type: array
                     items: string
-                    default: ['any']
                   enabled:
                     description: "Status of the rules to restrict (enabled vs disabled)."
                     type: boolean or string
                     enum: [true, false, "any"]
-                    default: "any"
             required: [ "rules" ]
   targets:
     validation.gcp.forsetisecurity.org:

--- a/policies/templates/gcp_restricted_firewall_rules_v1.yaml
+++ b/policies/templates/gcp_restricted_firewall_rules_v1.yaml
@@ -151,7 +151,7 @@ spec:
                     description: "Status of the rules to restrict (enabled vs disabled)."
                     type: boolean or string
                     enum: [true, false, "any"]
-            required: [ "rules" ]
+          required: [ "rules" ]
   targets:
     validation.gcp.forsetisecurity.org:
       rego: | #INLINE("validator/restricted_firewall_rules.rego")

--- a/policies/templates/gcp_vpc_sc_ip_range_v1.yaml
+++ b/policies/templates/gcp_vpc_sc_ip_range_v1.yaml
@@ -28,8 +28,8 @@ spec:
             maximum_cidr_size:
               type: integer
               description: "Maximum size in CIDR notation for an IP network"
-              minimum: 0
-              maximum: 32
+              #minimum: 0
+              #maximum: 32
   targets:
     validation.gcp.forsetisecurity.org:
       rego: | #INLINE("validator/vpc_sc_ip_range.rego")

--- a/samples/gke_enable_stackdriver_kubernetes_engine_monitoring.yaml
+++ b/samples/gke_enable_stackdriver_kubernetes_engine_monitoring.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPGKEEnableStackdriverKubernetesEngineMonitoringConstraintV1
+kind: GCPGKEEnableStackdriverKubernetesEngineMonitoringV1
 metadata:
   name: enable_gke_stackdriver_kubernetes_engine_monitoring
   annotations:

--- a/validator/gke_enable_stackdriver_kubernetes_engine_monitoring.rego
+++ b/validator/gke_enable_stackdriver_kubernetes_engine_monitoring.rego
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-package templates.gcp.GCPGKEEnableStackdriverKubernetesEngineMonitoringConstraintV1
+package templates.gcp.GCPGKEEnableStackdriverKubernetesEngineMonitoringV1
 
 import data.validator.gcp.lib as lib
 

--- a/validator/gke_enable_stackdriver_kubernetes_engine_monitoring_test.rego
+++ b/validator/gke_enable_stackdriver_kubernetes_engine_monitoring_test.rego
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-package templates.gcp.GCPGKEEnableStackdriverKubernetesEngineMonitoringConstraintV1
+package templates.gcp.GCPGKEEnableStackdriverKubernetesEngineMonitoringV1
 
 import data.validator.gcp.lib as lib
 

--- a/validator/test/fixtures/gke_enable_stackdriver_kubernetes_engine_monitoring/constraints/data.yaml
+++ b/validator/test/fixtures/gke_enable_stackdriver_kubernetes_engine_monitoring/constraints/data.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPGKEEnableStackdriverKubernetesEngineMonitoringConstraintV1
+kind: GCPGKEEnableStackdriverKubernetesEngineMonitoringV1
 metadata:
   name: enable_gke_stackdriver_kubernetes_engine_monitoring
   annotations:


### PR DESCRIPTION
The constraint framework migration made FCV pickier about the input since it's actually looking at the fields.  There were some issues in the existing policy library constraint templates that this fixes.