### PR TITLE
Fanchen/fix globmatch call

### DIFF
--- a/samples/iam_blacklist_service_account_creator_role.yaml
+++ b/samples/iam_blacklist_service_account_creator_role.yaml
@@ -16,4 +16,4 @@ spec:
     assetType: cloudresourcemanager.googleapis.com/Project
     role: roles/iam.serviceAccountTokenCreator
     members:
-    - "*"
+    - "*" # Although it is still okay to use "*" to match all, consider using "**" (see https://www.openpolicyagent.org/docs/latest/policy-reference/#glob)

--- a/validator/iam_allow_ban_roles.rego
+++ b/validator/iam_allow_ban_roles.rego
@@ -29,7 +29,7 @@ deny[{
 	binding := asset.iam_policy.bindings[_]
 	role := binding.role
 
-	matches_found = {r | r := role; glob.match(params.roles[_], [], r)}
+	matches_found = {r | r := role; glob.match(params.roles[_], ["/"], r)}
 
 	mode := lib.get_default(params, "mode", "allow")
 

--- a/validator/iam_allowed_bindings.rego
+++ b/validator/iam_allowed_bindings.rego
@@ -32,11 +32,11 @@ deny[{
 	member := binding.members[_]
 	role := binding.role
 
-	glob.match(params.role, [], role)
+	glob.match(params.role, ["/"], role)
 
 	mode := lib.get_default(params, "mode", "whitelist")
 
-	matches_found = [m | m = params.members[_]; glob.match(m, [], member)]
+	matches_found = [m | m = config_pattern(params.members[_]); glob.match(m, [], member)]
 	target_match_count(mode, desired_count)
 	count(matches_found) != desired_count
 
@@ -69,4 +69,14 @@ check_asset_type(asset, params) {
 
 check_asset_type(asset, params) {
 	lib.has_field(params, "assetType") == false
+}
+
+# If the member in constraint is written as a single "*", turn it into super
+# glob "**". Otherwise, we won't be able to match everything.
+config_pattern(old_pattern) = "**" {
+	old_pattern == "*"
+}
+
+config_pattern(old_pattern) = old_pattern {
+	old_pattern != "*"
 }


### PR DESCRIPTION
Bug fix report:

There are three failed test cases when using OPA v0.17.

1. `data.templates.gcp.GCPIAMAllowBanRolesConstraintV1.test_allow_all_roles_wildcard_violations: FAIL (2.199779ms)`


2. `data.templates.gcp.GCPIAMAllowBanRolesConstraintV1.test_ban_all_roles_wildcard_violations: FAIL (2.644217ms)`

3. `data.templates.gcp.GCPIAMAllowedBindingsConstraintV1.test_blacklist_role_violations: FAIL (2.5466ms)`

The first two failures are resolved by using the `"/"` delimiter in `glob.match()` in `validator/iam_allow_ban_roles.rego`. Specifically, `glob.match(params.roles[_], [], r)` is changed into `glob.match(params.roles[_], ["/"], r)`. In OPA v0.17, the default delimiter is `"."`. Thus, in order to match roles, we have to specify `"/"` as delimiter.

The third failure concerns `validator/iam_allowed_binding.rego`, the test asset is under `validator/test/fixtures/iam_allowed_bindings/assets/data.json`, and the test constraint is under `validator/test/fixtures/iam_allowed_bindings/constraints/iam_allowed_bindings_blacklist_role/data.yaml`. The problem is not with the delimiter at `glob.match(params.role, [], role)`, because `glob.match("roles/iam.serviceAccountUser", [], "roles/iam.serviceAccountUser")` returns `true` as expected. That said, it is still changed to `glob.match(params.role, ["/"], role)` because `glob.match("role/*", [], "role/iam.serviceAccountUser")` returns `false`, which is not expected.

The problem is with `glob.match(m, [], member)`. The matching pattern obtained from the constraint is `"*"`. The stirng to match is `"user:bad@notgoogle.com"` and `"serviceAccount:service-12345@notiam.gserviceaccount.com"`. Surprisingly, under OPA v0.17, both `glob.match("*", [], "user:bad@notgoogle.com")` and `glob.match("*", [], "serviceAccount:service-12345@notiam.gserviceaccount.com")` evaluate to `false`. This leads to the failed test.

There must have been a change in OPA regarding how `"*"` is treated, because the two failed matches mentioned above evaluate to `true` under OPA v0.12.

A simple fix for this is to use `"**"` (super glob) in the constraint. In order to not force the change on how users write constraints, this fix is internalized in `validator/iam_allowed_binding.rego` by checking whether the pattern is a single `"*"`. If it is, the pattern turns into `"**"`; otherwise, it stays the same.

A comment is added to `samples/iam_blacklist_service_account_creator_role.yaml`, suggesting switching to `"**"` for match-all pattern.