### PR TITLE
Fixed GCPBigQueryDatasetWorldReadableConstraintV1

### DIFF
--- a/validator/bigquery_dataset_world_readable.rego
+++ b/validator/bigquery_dataset_world_readable.rego
@@ -24,7 +24,10 @@ deny[{
 	asset := input.asset
 	asset.asset_type == "bigquery.googleapis.com/Dataset"
 
-	asset.iam_policy.bindings[_].members[_] == "allAuthenticatedUsers"
+	world_readable_checks := [
+		asset.iam_policy.bindings[_].members[_] == "allUsers",
+		asset.iam_policy.bindings[_].members[_] == "allAuthenticatedUsers",
+	]
 
 	message := sprintf("%v is publicly accessable", [asset.name])
 	metadata := {"resource": asset.name}

--- a/validator/bigquery_dataset_world_readable_test.rego
+++ b/validator/bigquery_dataset_world_readable_test.rego
@@ -28,9 +28,11 @@ all_violations[violation] {
 
 # Confirm total violations count
 test_bigquery_iam_violations_count {
-	count(all_violations) == 1
+	count(all_violations) == 4
 }
 
 test_bigquery_iam_violations {
-	all_violations[_].details.resource == "//bigquery.googleapis.com/projects/test-project/datasets/world-readable"
+	all_violations[_].details.resource == "//bigquery.googleapis.com/projects/test-project/datasets/world-readable-allUsers"
+	all_violations[_].details.resource == "//bigquery.googleapis.com/projects/test-project/datasets/world-readable-allAuthenticatedUsers"
+	all_violations[_].details.resource == "//bigquery.googleapis.com/projects/test-project/datasets/world-readable-both"
 }

--- a/validator/test/fixtures/bigquery_dataset_world_readable/assets/data.json
+++ b/validator/test/fixtures/bigquery_dataset_world_readable/assets/data.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "//bigquery.googleapis.com/projects/test-project/datasets/world-readable",
+    "name": "//bigquery.googleapis.com/projects/test-project/datasets/world-readable-allAuthenticatedUsers",
     "asset_type": "bigquery.googleapis.com/Dataset",
     "iam_policy": {
       "etag": "BwWV9DYRcXA=",
@@ -21,6 +21,63 @@
           "role": "roles/bigquery.dataViewer",
           "members": [
             "allAuthenticatedUsers",
+            "projectViewer:test-viewer"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "//bigquery.googleapis.com/projects/test-project/datasets/world-readable-allUsers",
+    "asset_type": "bigquery.googleapis.com/Dataset",
+    "iam_policy": {
+      "etag": "BwWV9DYRcXA=",
+      "bindings": [
+        {
+          "role": "roles/bigquery.dataEditor",
+          "members": [
+            "projectEditor:test-editor"
+          ]
+        },
+        {
+          "role": "roles/bigquery.dataOwner",
+          "members": [
+            "projectOwner:test-owner"
+          ]
+        },
+        {
+          "role": "roles/bigquery.dataViewer",
+          "members": [
+            "allUsers",
+            "projectViewer:test-viewer"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "//bigquery.googleapis.com/projects/test-project/datasets/world-readable-both",
+    "asset_type": "bigquery.googleapis.com/Dataset",
+    "iam_policy": {
+      "etag": "BwWV9DYRcXA=",
+      "bindings": [
+        {
+          "role": "roles/bigquery.dataEditor",
+          "members": [
+            "projectEditor:test-editor"
+          ]
+        },
+        {
+          "role": "roles/bigquery.dataOwner",
+          "members": [
+            "projectOwner:test-owner"
+          ]
+        },
+        {
+          "role": "roles/bigquery.dataViewer",
+          "members": [
+            "allAuthenticatedUsers",
+            "allUsers",
             "projectViewer:test-viewer"
           ]
         }


### PR DESCRIPTION
`GCPBigQueryDatasetWorldReadableConstraintV1` checks for `allAuthenticatedUsers `, but not for `allUsers ` like `GCPStorageBucketWorldReadableConstraintV1 ` does.