### PR TITLE
BigQuery Table Retention Constraint v1

### DIFF
--- a/policies/templates/gcp_bigquery_table_retention_v1.yaml
+++ b/policies/templates/gcp_bigquery_table_retention_v1.yaml
@@ -1,0 +1,163 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: templates.gatekeeper.sh/v1alpha1
+kind: ConstraintTemplate
+metadata:
+  name: gcp_bigquery_table_retention_v1
+spec:
+  crd:
+    spec:
+      names:
+        kind: GCPBigQueryTableRetentionConstraintV1
+      validation:
+        openAPIV3Schema:
+          properties:
+            required: ["retention_type", "retention_days"]
+            retention_type:
+              type: string
+              enum: [minimum, maximum, minimum_maximum]
+              description: "String describing which type of retention policy to look for.
+              minimum identifies the minimum number of days the retention of a BigQuery table should be.
+              Generate a violation if the resource retention is less than the minimum number of retention days allowed.
+              maximum identifies the maximum number of days the retention of a BigQuery table can be.
+              Generate a violation if the resource retention is greater than the maximum number of retention days allowed.
+              Generate a violation if expirationTime does not exist when looking at the maximum retention.
+              minimum_maximum identifies the range of days the retention of a BigQuery table should be between,
+              which should include BOTH a minimum and maximum number."
+            retention_days:
+              type: array
+              items: integer
+              description: "Array of days that a BigQuery table life should be limited to.
+              If the minimum OR maximum retention_type is selected, define only one value.
+              If the minimum_maximum retention_type is selected, define the minimum and maximum values.
+              Violations are generated if table retention is greater than the maximum retention value.
+              Violations are generated if table retention is less than the minimum retention value.
+              E.g. minimum is selected as the retention_type, retention_days = 100:
+              Any BigQuery tables that have a retention less than 100 days will generate a violation.
+              minimum_maximum is selected as the retention_type, retention_days= 100, 200:
+              Any BigQuery tables that have a retention less than 100 days OR greater than 200 days OR does not have an expirationTime
+              will generate a violation."
+            exemptions:
+              type: array
+              items: string
+              description: "Array of BigQuery tables to exempt from retention restriction. String values in the array
+              should correspond to the full name values of exempted BigQuery tables, e.g.
+              //bigquery.googleapis.com/projects/project-abc/datasets/my-dataset/tables/my-table."
+  targets:
+    validation.gcp.forsetisecurity.org:
+      rego: | #INLINE("validator/bigquery_table_retention.rego")
+          #
+          # Copyright 2020 Google LLC
+          #
+          # Licensed under the Apache License, Version 2.0 (the "License");
+          # you may not use this file except in compliance with the License.
+          # You may obtain a copy of the License at
+          #
+          #      http://www.apache.org/licenses/LICENSE-2.0
+          #
+          # Unless required by applicable law or agreed to in writing, software
+          # distributed under the License is distributed on an "AS IS" BASIS,
+          # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+          # See the License for the specific language governing permissions and
+          # limitations under the License.
+          #
+          
+          package templates.gcp.GCPBigQueryTableRetentionConstraintV1
+          
+          import data.validator.gcp.lib as lib
+          
+          deny[{
+          	"msg": message,
+          	"details": metadata,
+          }] {
+          	constraint := input.constraint
+          	lib.get_constraint_params(constraint, params)
+          
+          	retention_type := params.retention_type
+          	retention_days := params.retention_days
+          
+          	asset := input.asset
+          	asset.asset_type == "bigquery.googleapis.com/Table"
+          
+          	# Check if resource is in exempt list
+          	exempt_list := params.exemptions
+          	matches := {asset.name} & cast_set(exempt_list)
+          	count(matches) == 0
+          
+          	get_diff(asset, retention_type, retention_days)
+          
+          	message := sprintf("BigQuery table %v has a retention policy violation of retention_type: %v", [asset.name, retention_type])
+          	metadata := {"resource": asset.name, "retention_type_violation": retention_type}
+          }
+          
+          ###########################
+          # Rule Utilities
+          ###########################
+          
+          # Generate a violation if the resource retention is greater than the maximum number of retention days allowed.
+          get_diff(asset, retention_type, retention_days) {
+          	maximum_retention_types := {
+          		"maximum",
+          		"minimum_maximum",
+          	}
+          
+          	retention_type == maximum_retention_types[_]
+          	creation_time := to_number(asset.resource.data.creationTime)
+          	retention_days_max := max(retention_days)
+          	retention_days_ms := get_ms_of_retention_days(retention_days_max)
+          	get_expiration_time := object.get(asset.resource.data, "expirationTime", "")
+          	get_expiration_time != ""
+          	expiration_time := to_number(get_expiration_time)
+          
+          	diff := expiration_time - creation_time
+          	diff > retention_days_ms
+          }
+          
+          # If expirationTime does not exist when looking at the maximum retention, generate a violation.
+          get_diff(asset, retention_type, retention_days) {
+          	maximum_retention_types := {
+          		"maximum",
+          		"minimum_maximum",
+          	}
+          
+          	retention_type == maximum_retention_types[_]
+          	creation_time := to_number(asset.resource.data.creationTime)
+          	get_expiration_time := object.get(asset.resource.data, "expirationTime", "")
+          	get_expiration_time == ""
+          }
+          
+          # Generate a violation if the resource retention is less than the minimum number of retention days allowed.
+          get_diff(asset, retention_type, retention_days) {
+          	minimum_retention_types := {
+          		"minimum",
+          		"minimum_maximum",
+          	}
+          
+          	retention_type == minimum_retention_types[_]
+          	creation_time := to_number(asset.resource.data.creationTime)
+          	retention_days_min := min(retention_days)
+          	retention_days_ms := get_ms_of_retention_days(retention_days_min)
+          	expiration_time := to_number(object.get(asset.resource.data, "expirationTime", retention_days_ms * creation_time))
+          
+          	diff := expiration_time - creation_time
+          	diff < retention_days_ms
+          }
+          
+          # Convert retention days to ms as resource data is in ms for better comparison.
+          get_ms_of_retention_days(retention_days) = retention_days_ms {
+          	ms_per_day := ((24 * 60) * 60) * 1000
+          	retention_days_ms := retention_days * ms_per_day
+          }
+          #ENDINLINE

--- a/policies/templates/gcp_bigquery_table_retention_v1.yaml
+++ b/policies/templates/gcp_bigquery_table_retention_v1.yaml
@@ -24,31 +24,25 @@ spec:
       validation:
         openAPIV3Schema:
           properties:
-            required: ["retention_type", "retention_days"]
-            retention_type:
-              type: string
-              enum: [minimum, maximum, minimum_maximum]
-              description: "String describing which type of retention policy to look for.
-              minimum identifies the minimum number of days the retention of a BigQuery table should be.
-              Generate a violation if the resource retention is less than the minimum number of retention days allowed.
-              maximum identifies the maximum number of days the retention of a BigQuery table can be.
+            minimum_retention_days:
+              type: integer
+              description: "Minimum number of days that a BigQuery table life should be.
+              Generate a violation if the resource retention is less than the minimum number of
+              retention days allowed.
+              E.g. minimum_retention_days: 100 -->
+              Any BigQuery tables that have a retention less than 100 days will generate a violation."
+            maximum_retention_days:
+              type: integer
+              description: "Maximum number of days that a BigQuery table life should be limited to.
               Generate a violation if the resource retention is greater than the maximum number of retention days allowed.
               Generate a violation if expirationTime does not exist when looking at the maximum retention.
-              minimum_maximum identifies the range of days the retention of a BigQuery table should be between,
-              which should include BOTH a minimum and maximum number."
-            retention_days:
-              type: array
-              items: integer
-              description: "Array of days that a BigQuery table life should be limited to.
-              If the minimum OR maximum retention_type is selected, define only one value.
-              If the minimum_maximum retention_type is selected, define the minimum and maximum values.
-              Violations are generated if table retention is greater than the maximum retention value.
-              Violations are generated if table retention is less than the minimum retention value.
-              E.g. minimum is selected as the retention_type, retention_days = 100:
-              Any BigQuery tables that have a retention less than 100 days will generate a violation.
-              minimum_maximum is selected as the retention_type, retention_days= 100, 200:
-              Any BigQuery tables that have a retention less than 100 days OR greater than 200 days OR does not have an expirationTime
-              will generate a violation."
+              E.g. maximum_retention_days: 200 -->
+              Any BigQuery tables that have a retention greater than 200 days will generate a violation.
+              NOTE: Add values for both minimum_retention_days and maximum_retention_days to define a range of days that
+              the resource retention should be within.
+              E.g. minimum_retention_days: 100 and maximum_retention_days: 200 -->
+              Any BigQuery tables that have a retention less than 100 days OR greater than 200 days OR does not have
+              an expirationTime will generate a violation."
             exemptions:
               type: array
               items: string
@@ -58,106 +52,89 @@ spec:
   targets:
     validation.gcp.forsetisecurity.org:
       rego: | #INLINE("validator/bigquery_table_retention.rego")
-          #
-          # Copyright 2020 Google LLC
-          #
-          # Licensed under the Apache License, Version 2.0 (the "License");
-          # you may not use this file except in compliance with the License.
-          # You may obtain a copy of the License at
-          #
-          #      http://www.apache.org/licenses/LICENSE-2.0
-          #
-          # Unless required by applicable law or agreed to in writing, software
-          # distributed under the License is distributed on an "AS IS" BASIS,
-          # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-          # See the License for the specific language governing permissions and
-          # limitations under the License.
-          #
-          
-          package templates.gcp.GCPBigQueryTableRetentionConstraintV1
-          
-          import data.validator.gcp.lib as lib
-          
-          deny[{
-          	"msg": message,
-          	"details": metadata,
-          }] {
-          	constraint := input.constraint
-          	lib.get_constraint_params(constraint, params)
-          
-          	retention_type := params.retention_type
-          	retention_days := params.retention_days
-          
-          	asset := input.asset
-          	asset.asset_type == "bigquery.googleapis.com/Table"
-          
-          	# Check if resource is in exempt list
-          	exempt_list := params.exemptions
-          	matches := {asset.name} & cast_set(exempt_list)
-          	count(matches) == 0
-          
-          	get_diff(asset, retention_type, retention_days)
-          
-          	message := sprintf("BigQuery table %v has a retention policy violation of retention_type: %v", [asset.name, retention_type])
-          	metadata := {"resource": asset.name, "retention_type_violation": retention_type}
-          }
-          
-          ###########################
-          # Rule Utilities
-          ###########################
-          
-          # Generate a violation if the resource retention is greater than the maximum number of retention days allowed.
-          get_diff(asset, retention_type, retention_days) {
-          	maximum_retention_types := {
-          		"maximum",
-          		"minimum_maximum",
-          	}
-          
-          	retention_type == maximum_retention_types[_]
-          	creation_time := to_number(asset.resource.data.creationTime)
-          	retention_days_max := max(retention_days)
-          	retention_days_ms := get_ms_of_retention_days(retention_days_max)
-          	get_expiration_time := object.get(asset.resource.data, "expirationTime", "")
-          	get_expiration_time != ""
-          	expiration_time := to_number(get_expiration_time)
-          
-          	diff := expiration_time - creation_time
-          	diff > retention_days_ms
-          }
-          
-          # If expirationTime does not exist when looking at the maximum retention, generate a violation.
-          get_diff(asset, retention_type, retention_days) {
-          	maximum_retention_types := {
-          		"maximum",
-          		"minimum_maximum",
-          	}
-          
-          	retention_type == maximum_retention_types[_]
-          	creation_time := to_number(asset.resource.data.creationTime)
-          	get_expiration_time := object.get(asset.resource.data, "expirationTime", "")
-          	get_expiration_time == ""
-          }
-          
-          # Generate a violation if the resource retention is less than the minimum number of retention days allowed.
-          get_diff(asset, retention_type, retention_days) {
-          	minimum_retention_types := {
-          		"minimum",
-          		"minimum_maximum",
-          	}
-          
-          	retention_type == minimum_retention_types[_]
-          	creation_time := to_number(asset.resource.data.creationTime)
-          	retention_days_min := min(retention_days)
-          	retention_days_ms := get_ms_of_retention_days(retention_days_min)
-          	expiration_time := to_number(object.get(asset.resource.data, "expirationTime", retention_days_ms * creation_time))
-          
-          	diff := expiration_time - creation_time
-          	diff < retention_days_ms
-          }
-          
-          # Convert retention days to ms as resource data is in ms for better comparison.
-          get_ms_of_retention_days(retention_days) = retention_days_ms {
-          	ms_per_day := ((24 * 60) * 60) * 1000
-          	retention_days_ms := retention_days * ms_per_day
-          }
-          #ENDINLINE
+         #
+         # Copyright 2020 Google LLC
+         #
+         # Licensed under the Apache License, Version 2.0 (the "License");
+         # you may not use this file except in compliance with the License.
+         # You may obtain a copy of the License at
+         #
+         #      http://www.apache.org/licenses/LICENSE-2.0
+         #
+         # Unless required by applicable law or agreed to in writing, software
+         # distributed under the License is distributed on an "AS IS" BASIS,
+         # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+         # See the License for the specific language governing permissions and
+         # limitations under the License.
+         #
+         
+         package templates.gcp.GCPBigQueryTableRetentionConstraintV1
+         
+         import data.validator.gcp.lib as lib
+         
+         deny[{
+         	"msg": message,
+         	"details": metadata,
+         }] {
+         	constraint := input.constraint
+         	lib.get_constraint_params(constraint, params)
+         
+         	min_retention_days := lib.get_default(params, "minimum_retention_days", "")
+         	max_retention_days := lib.get_default(params, "maximum_retention_days", "")
+         
+         	asset := input.asset
+         	asset.asset_type == "bigquery.googleapis.com/Table"
+         
+         	# Check if resource is in exempt list
+         	exempt_list := params.exemptions
+         	matches := {asset.name} & cast_set(exempt_list)
+         	count(matches) == 0
+         
+         	get_diff(asset, min_retention_days, max_retention_days)
+         
+         	message := sprintf("BigQuery table %v has a retention policy violation.", [asset.name])
+         	metadata := {"resource": asset.name}
+         }
+         
+         ###########################
+         # Rule Utilities
+         ###########################
+         
+         # Generate a violation if the resource retention is greater than the maximum number of retention days allowed.
+         get_diff(asset, minimum_retention_days, maximum_retention_days) {
+         	maximum_retention_days != ""
+         	creation_time := to_number(asset.resource.data.creationTime)
+         	retention_days_ms := get_ms_of_retention_days(maximum_retention_days)
+         	get_expiration_time := object.get(asset.resource.data, "expirationTime", "")
+         	get_expiration_time != ""
+         	expiration_time := to_number(get_expiration_time)
+         
+         	diff := expiration_time - creation_time
+         	diff > retention_days_ms
+         }
+         
+         # If expirationTime does not exist when looking at the maximum retention, generate a violation.
+         get_diff(asset, minimum_retention_days, maximum_retention_days) {
+         	maximum_retention_days != ""
+         	creation_time := to_number(asset.resource.data.creationTime)
+         	get_expiration_time := object.get(asset.resource.data, "expirationTime", "")
+         	get_expiration_time == ""
+         }
+         
+         # Generate a violation if the resource retention is less than the minimum number of retention days allowed.
+         get_diff(asset, minimum_retention_days, maximum_retention_days) {
+         	minimum_retention_days != ""
+         	creation_time := to_number(asset.resource.data.creationTime)
+         	retention_days_ms := get_ms_of_retention_days(minimum_retention_days)
+         	expiration_time := to_number(object.get(asset.resource.data, "expirationTime", retention_days_ms * creation_time))
+         
+         	diff := expiration_time - creation_time
+         	diff < retention_days_ms
+         }
+         
+         # Convert retention days to ms as resource data is in ms for better comparison.
+         get_ms_of_retention_days(retention_days) = retention_days_ms {
+         	ms_per_day := ((24 * 60) * 60) * 1000
+         	retention_days_ms := retention_days * ms_per_day
+         }
+         #ENDINLINE

--- a/policies/templates/gcp_bigquery_table_retention_v1.yaml
+++ b/policies/templates/gcp_bigquery_table_retention_v1.yaml
@@ -90,10 +90,15 @@ spec:
          	matches := {asset.name} & cast_set(exempt_list)
          	count(matches) == 0
          
-         	get_diff(asset, min_retention_days, max_retention_days)
+         	violation_msg := get_diff(asset, min_retention_days, max_retention_days)
+         	is_string(violation_msg)
          
-         	message := sprintf("BigQuery table %v has a retention policy violation.", [asset.name])
-         	metadata := {"resource": asset.name}
+         	message := sprintf("BigQuery table %v has a retention policy violation: %v", [asset.name, violation_msg])
+         
+         	metadata := {
+         		"resource": asset.name,
+         		"violation_type": violation_msg,
+         	}
          }
          
          ###########################
@@ -101,7 +106,7 @@ spec:
          ###########################
          
          # Generate a violation if the resource retention is greater than the maximum number of retention days allowed.
-         get_diff(asset, minimum_retention_days, maximum_retention_days) {
+         get_diff(asset, minimum_retention_days, maximum_retention_days) = "Greater than maximum_retention_days" {
          	maximum_retention_days != ""
          	creation_time := to_number(asset.resource.data.creationTime)
          	retention_days_ms := get_ms_of_retention_days(maximum_retention_days)
@@ -114,14 +119,14 @@ spec:
          }
          
          # If expirationTime does not exist when looking at the maximum retention, generate a violation.
-         get_diff(asset, minimum_retention_days, maximum_retention_days) {
+         get_diff(asset, minimum_retention_days, maximum_retention_days) = "ExpirationTime does not exist" {
          	maximum_retention_days != ""
          	get_expiration_time := object.get(asset.resource.data, "expirationTime", "")
          	get_expiration_time == ""
          }
          
          # Generate a violation if the resource retention is less than the minimum number of retention days allowed.
-         get_diff(asset, minimum_retention_days, maximum_retention_days) {
+         get_diff(asset, minimum_retention_days, maximum_retention_days) = "Less than minimum_retention_days" {
          	minimum_retention_days != ""
          	creation_time := to_number(asset.resource.data.creationTime)
          	retention_days_ms := get_ms_of_retention_days(minimum_retention_days)

--- a/policies/templates/gcp_bigquery_table_retention_v1.yaml
+++ b/policies/templates/gcp_bigquery_table_retention_v1.yaml
@@ -116,7 +116,6 @@ spec:
          # If expirationTime does not exist when looking at the maximum retention, generate a violation.
          get_diff(asset, minimum_retention_days, maximum_retention_days) {
          	maximum_retention_days != ""
-         	creation_time := to_number(asset.resource.data.creationTime)
          	get_expiration_time := object.get(asset.resource.data, "expirationTime", "")
          	get_expiration_time == ""
          }

--- a/samples/bigquery_table_retention.yaml
+++ b/samples/bigquery_table_retention.yaml
@@ -21,8 +21,6 @@ spec:
   match:
     target: ["organization/*"]
   parameters:
-    retention_type: "minimum_maximum"
-    retention_days:
-      - 100
-      - 200
+    minimum_retention_days: 100
+    maximum_retention_days: 200
     exemptions: []

--- a/samples/bigquery_table_retention.yaml
+++ b/samples/bigquery_table_retention.yaml
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPBigQueryTableRetentionConstraintV1
+metadata:
+  name: bq_table_minimum_maximum_retention
+spec:
+  severity: high
+  match:
+    target: ["organization/*"]
+  parameters:
+    retention_type: "minimum_maximum"
+    retention_days:
+      - 100
+      - 200
+    exemptions: []

--- a/validator/bigquery_table_retention.rego
+++ b/validator/bigquery_table_retention.rego
@@ -1,0 +1,102 @@
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package templates.gcp.GCPBigQueryTableRetentionConstraintV1
+
+import data.validator.gcp.lib as lib
+
+deny[{
+	"msg": message,
+	"details": metadata,
+}] {
+	constraint := input.constraint
+	lib.get_constraint_params(constraint, params)
+
+	retention_type := params.retention_type
+	retention_days := params.retention_days
+
+	asset := input.asset
+	asset.asset_type == "bigquery.googleapis.com/Table"
+
+	# Check if resource is in exempt list
+	exempt_list := params.exemptions
+	matches := {asset.name} & cast_set(exempt_list)
+	count(matches) == 0
+
+	get_diff(asset, retention_type, retention_days)
+
+	message := sprintf("BigQuery table %v has a retention policy violation of retention_type: %v", [asset.name, retention_type])
+	metadata := {"resource": asset.name, "retention_type_violation": retention_type}
+}
+
+###########################
+# Rule Utilities
+###########################
+
+# Generate a violation if the resource retention is greater than the maximum number of retention days allowed.
+get_diff(asset, retention_type, retention_days) {
+	maximum_retention_types := {
+		"maximum",
+		"minimum_maximum",
+	}
+
+	retention_type == maximum_retention_types[_]
+	creation_time := to_number(asset.resource.data.creationTime)
+	retention_days_max := max(retention_days)
+	retention_days_ms := get_ms_of_retention_days(retention_days_max)
+	get_expiration_time := object.get(asset.resource.data, "expirationTime", "")
+	get_expiration_time != ""
+	expiration_time := to_number(get_expiration_time)
+
+	diff := expiration_time - creation_time
+	diff > retention_days_ms
+}
+
+# If expirationTime does not exist when looking at the maximum retention, generate a violation.
+get_diff(asset, retention_type, retention_days) {
+	maximum_retention_types := {
+		"maximum",
+		"minimum_maximum",
+	}
+
+	retention_type == maximum_retention_types[_]
+	creation_time := to_number(asset.resource.data.creationTime)
+	get_expiration_time := object.get(asset.resource.data, "expirationTime", "")
+	get_expiration_time == ""
+}
+
+# Generate a violation if the resource retention is less than the minimum number of retention days allowed.
+get_diff(asset, retention_type, retention_days) {
+	minimum_retention_types := {
+		"minimum",
+		"minimum_maximum",
+	}
+
+	retention_type == minimum_retention_types[_]
+	creation_time := to_number(asset.resource.data.creationTime)
+	retention_days_min := min(retention_days)
+	retention_days_ms := get_ms_of_retention_days(retention_days_min)
+	expiration_time := to_number(object.get(asset.resource.data, "expirationTime", retention_days_ms * creation_time))
+
+	diff := expiration_time - creation_time
+	diff < retention_days_ms
+}
+
+# Convert retention days to ms as resource data is in ms for better comparison.
+get_ms_of_retention_days(retention_days) = retention_days_ms {
+	ms_per_day := ((24 * 60) * 60) * 1000
+	retention_days_ms := retention_days * ms_per_day
+}

--- a/validator/bigquery_table_retention.rego
+++ b/validator/bigquery_table_retention.rego
@@ -62,7 +62,6 @@ get_diff(asset, minimum_retention_days, maximum_retention_days) {
 # If expirationTime does not exist when looking at the maximum retention, generate a violation.
 get_diff(asset, minimum_retention_days, maximum_retention_days) {
 	maximum_retention_days != ""
-	creation_time := to_number(asset.resource.data.creationTime)
 	get_expiration_time := object.get(asset.resource.data, "expirationTime", "")
 	get_expiration_time == ""
 }

--- a/validator/bigquery_table_retention_test.rego
+++ b/validator/bigquery_table_retention_test.rego
@@ -1,0 +1,195 @@
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package templates.gcp.GCPBigQueryTableRetentionConstraintV1
+
+# Importing the test data
+import data.test.fixtures.bigquery_table_retention.assets as fixture_assets
+
+# Importing the test constraints
+import data.test.fixtures.bigquery_table_retention.constraints.max_retention_only as max_retention_only
+import data.test.fixtures.bigquery_table_retention.constraints.max_retention_only_one_exemption as max_retention_only_one_exemption
+import data.test.fixtures.bigquery_table_retention.constraints.min_max_retention as min_max_retention
+import data.test.fixtures.bigquery_table_retention.constraints.min_max_retention_one_exemption as min_max_retention_one_exemption
+import data.test.fixtures.bigquery_table_retention.constraints.min_retention_only as min_retention_only
+import data.test.fixtures.bigquery_table_retention.constraints.min_retention_only_one_exemption as min_retention_only_one_exemption
+
+# Find all violations on our test cases
+find_all_violations[violation] {
+	resources := data.resources[_]
+	constraint := data.test_constraints[_]
+	issues := deny with input.asset as resources
+		 with input.constraint as constraint
+
+	violation := issues[_]
+}
+
+# Test for no violations with no assets
+test_bigquery_table_retention_no_assets {
+	violations := find_all_violations with data.resources as []
+
+	count(violations) == 0
+}
+
+# Test for maximum retention
+violations_with_maximum_retention[violation] {
+	constraints := [max_retention_only]
+	violations := find_all_violations with data.resources as fixture_assets
+		 with data.test_constraints as constraints
+
+	violation := violations[_]
+}
+
+test_bigquery_table_retention_max_retention {
+	violations := violations_with_maximum_retention
+
+	count(violations) == 2
+
+	resource_names := {x | x = violations[_].details.resource}
+
+	expected_resource_names := {
+		"//bigquery.googleapis.com/projects/forseti-ia/datasets/forseti/tables/forseti_fw_rules",
+		"//bigquery.googleapis.com/projects/forseti-ia/datasets/forseti_ml/tables/sample_data",
+	}
+
+	resource_names == expected_resource_names
+
+	violation := violations[_]
+	is_string(violation.msg)
+	is_object(violation.details)
+}
+
+# Test for minimum retention
+violations_with_minimum_retention[violation] {
+	constraints := [min_retention_only]
+	violations := find_all_violations with data.resources as fixture_assets
+		 with data.test_constraints as constraints
+
+	violation := violations[_]
+}
+
+test_bigquery_table_retention_min_retention {
+	violations := violations_with_minimum_retention
+
+	count(violations) == 1
+
+	resource_names := {x | x = violations[_].details.resource}
+
+	expected_resource_names := {"//bigquery.googleapis.com/projects/forseti-test-110/datasets/my_bq_dataset/tables/my_bq_table"}
+
+	resource_names == expected_resource_names
+
+	violation := violations[_]
+	is_string(violation.msg)
+	is_object(violation.details)
+}
+
+# Test for minimum and maximum retention
+violations_with_minimum_maximum_retention[violation] {
+	constraints := [min_max_retention]
+	violations := find_all_violations with data.resources as fixture_assets
+		 with data.test_constraints as constraints
+
+	violation := violations[_]
+}
+
+test_bigquery_table_retention_min_max_retention {
+	violations := violations_with_minimum_maximum_retention
+
+	count(violations) == count(fixture_assets)
+
+	resource_names := {x | x = violations[_].details.resource}
+
+	expected_resource_names := {
+		"//bigquery.googleapis.com/projects/forseti-test-110/datasets/my_bq_dataset/tables/my_bq_table",
+		"//bigquery.googleapis.com/projects/forseti-ia/datasets/forseti/tables/forseti_fw_rules",
+		"//bigquery.googleapis.com/projects/forseti-ia/datasets/forseti_ml/tables/sample_data",
+	}
+
+	resource_names == expected_resource_names
+
+	violation := violations[_]
+	is_string(violation.msg)
+	is_object(violation.details)
+}
+
+# Test for maximum retention with one exemption
+violations_with_maximum_retention_one_exemption[violation] {
+	constraints := [max_retention_only_one_exemption]
+	violations := find_all_violations with data.resources as fixture_assets
+		 with data.test_constraints as constraints
+
+	violation := violations[_]
+}
+
+test_bigquery_table_retention_max_retention_one_exemption {
+	violations := violations_with_maximum_retention_one_exemption
+
+	count(violations) == 1
+
+	resource_names := {x | x = violations[_].details.resource}
+
+	expected_resource_names := {"//bigquery.googleapis.com/projects/forseti-ia/datasets/forseti_ml/tables/sample_data"}
+
+	resource_names == expected_resource_names
+
+	violation := violations[_]
+	is_string(violation.msg)
+	is_object(violation.details)
+}
+
+# Test for minimum retention with one exemption
+violations_with_minimum_retention_one_exemption[violation] {
+	constraints := [min_retention_only_one_exemption]
+	violations := find_all_violations with data.resources as fixture_assets
+		 with data.test_constraints as constraints
+
+	violation := violations[_]
+}
+
+test_bigquery_table_retention_min_retention_one_exemption {
+	violations := violations_with_minimum_retention_one_exemption
+
+	count(violations) == 0
+}
+
+# Test for minimum and maximum retention with one exception
+violations_with_minimum_maximum_retention_one_exception[violation] {
+	constraints := [min_max_retention_one_exemption]
+	violations := find_all_violations with data.resources as fixture_assets
+		 with data.test_constraints as constraints
+
+	violation := violations[_]
+}
+
+test_bigquery_table_retention_min_max_retention_one_exception {
+	violations := violations_with_minimum_maximum_retention_one_exception
+
+	count(violations) == 2
+
+	resource_names := {x | x = violations[_].details.resource}
+
+	expected_resource_names := {
+		"//bigquery.googleapis.com/projects/forseti-ia/datasets/forseti/tables/forseti_fw_rules",
+		"//bigquery.googleapis.com/projects/forseti-ia/datasets/forseti_ml/tables/sample_data",
+	}
+
+	resource_names == expected_resource_names
+
+	violation := violations[_]
+	is_string(violation.msg)
+	is_object(violation.details)
+}

--- a/validator/test/fixtures/bigquery_table_retention/assets/data.json
+++ b/validator/test/fixtures/bigquery_table_retention/assets/data.json
@@ -1,0 +1,110 @@
+[
+{
+  "name": "//bigquery.googleapis.com/projects/forseti-test-110/datasets/my_bq_dataset/tables/my_bq_table",
+  "asset_type": "bigquery.googleapis.com/Table",
+  "resource": {
+    "version": "v2",
+    "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/bigquery/v2/rest",
+    "discovery_name": "Table",
+    "parent": "//bigquery.googleapis.com/projects/forseti-test-110/datasets/my_bq_dataset",
+    "data": {
+      "creationTime": "1573756788858",
+      "expirationTime": "1576348788639",
+      "id": "forseti-test-110:my_bq_dataset.my_bq_table",
+      "kind": "bigquery#table",
+      "location": "US",
+      "schema": {
+        "fields": [
+          {
+            "description": "",
+            "name": "name",
+            "type": "TYPE_STRING"
+          }
+        ]
+      },
+      "tableReference": {
+        "datasetId": "my_bq_dataset",
+        "projectId": "forseti-test-110",
+        "tableId": "my_bq_table"
+      }
+    }
+  },
+  "ancestors": [
+    "projects/342889460468",
+    "folders/37188445764",
+    "folders/138672061205",
+    "organizations/660570133860"
+  ]
+},
+{
+  "name": "//bigquery.googleapis.com/projects/forseti-ia/datasets/forseti/tables/forseti_fw_rules",
+  "asset_type": "bigquery.googleapis.com/Table",
+  "resource": {
+    "version": "v2",
+    "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/bigquery/v2/rest",
+    "discovery_name": "Table",
+    "parent": "//bigquery.googleapis.com/projects/forseti-ia/datasets/forseti",
+    "data": {
+      "creationTime": "1540577352884",
+      "id": "forseti-ia:forseti.forseti_fw_rules",
+      "kind": "bigquery#table",
+      "location": "US",
+      "schema": {},
+      "tableReference": {
+        "datasetId": "forseti",
+        "projectId": "forseti-ia",
+        "tableId": "forseti_fw_rules"
+      }
+    }
+  },
+  "ancestors": [
+    "projects/684804178670",
+    "organizations/660570133860"
+  ]
+},
+{
+  "name": "//bigquery.googleapis.com/projects/forseti-ia/datasets/forseti_ml/tables/sample_data",
+  "asset_type": "bigquery.googleapis.com/Table",
+  "resource": {
+    "version": "v2",
+    "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/bigquery/v2/rest",
+    "discovery_name": "Table",
+    "parent": "//bigquery.googleapis.com/projects/forseti-ia/datasets/forseti_ml",
+    "data": {
+      "creationTime": "1573756795782",
+      "expirationTime": "1579348795583",
+      "id": "forseti-ia:forseti_ml.sample_data",
+      "kind": "bigquery#table",
+      "location": "US",
+      "schema": {
+        "fields": [
+          {
+            "description": "",
+            "name": "int64_field_0",
+            "type": "TYPE_INT64"
+          },
+          {
+            "description": "",
+            "name": "disabled",
+            "type": "TYPE_BOOL"
+          },
+          {
+            "description": "",
+            "name": "ip_addr_4",
+            "type": "TYPE_INT64"
+          }
+        ]
+      },
+      "tableReference": {
+        "datasetId": "forseti_ml",
+        "projectId": "forseti-ia",
+        "tableId": "sample_data"
+      }
+    }
+  },
+  "ancestors": [
+    "projects/684804178670",
+    "organizations/660570133860"
+  ]
+}
+]

--- a/validator/test/fixtures/bigquery_table_retention/constraints/max_retention_only/data.yaml
+++ b/validator/test/fixtures/bigquery_table_retention/constraints/max_retention_only/data.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPBigQueryTableRetentionConstraintV1
+metadata:
+  name: bq_table_maximum_retention
+spec:
+  severity: high
+  match:
+    target: ["organization/*"]
+  parameters:
+    retention_type: "maximum"
+    retention_days:
+      - 60
+    exemptions: []

--- a/validator/test/fixtures/bigquery_table_retention/constraints/max_retention_only/data.yaml
+++ b/validator/test/fixtures/bigquery_table_retention/constraints/max_retention_only/data.yaml
@@ -21,7 +21,5 @@ spec:
   match:
     target: ["organization/*"]
   parameters:
-    retention_type: "maximum"
-    retention_days:
-      - 60
+    maximum_retention_days: 60
     exemptions: []

--- a/validator/test/fixtures/bigquery_table_retention/constraints/max_retention_only_one_exemption/data.yaml
+++ b/validator/test/fixtures/bigquery_table_retention/constraints/max_retention_only_one_exemption/data.yaml
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPBigQueryTableRetentionConstraintV1
+metadata:
+  name: bq_table_maximum_retention_one_exemption
+spec:
+  severity: high
+  match:
+    target: ["organization/*"]
+  parameters:
+    retention_type: "maximum"
+    retention_days:
+      - 60
+    exemptions:
+      - //bigquery.googleapis.com/projects/forseti-ia/datasets/forseti/tables/forseti_fw_rules

--- a/validator/test/fixtures/bigquery_table_retention/constraints/max_retention_only_one_exemption/data.yaml
+++ b/validator/test/fixtures/bigquery_table_retention/constraints/max_retention_only_one_exemption/data.yaml
@@ -21,8 +21,6 @@ spec:
   match:
     target: ["organization/*"]
   parameters:
-    retention_type: "maximum"
-    retention_days:
-      - 60
+    maximum_retention_days: 60
     exemptions:
       - //bigquery.googleapis.com/projects/forseti-ia/datasets/forseti/tables/forseti_fw_rules

--- a/validator/test/fixtures/bigquery_table_retention/constraints/min_max_retention/data.yaml
+++ b/validator/test/fixtures/bigquery_table_retention/constraints/min_max_retention/data.yaml
@@ -21,8 +21,6 @@ spec:
   match:
     target: ["organization/*"]
   parameters:
-    retention_type: "minimum_maximum"
-    retention_days:
-      - 31
-      - 60
+    minimum_retention_days: 31
+    maximum_retention_days: 60
     exemptions: []

--- a/validator/test/fixtures/bigquery_table_retention/constraints/min_max_retention/data.yaml
+++ b/validator/test/fixtures/bigquery_table_retention/constraints/min_max_retention/data.yaml
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPBigQueryTableRetentionConstraintV1
+metadata:
+  name: bq_table_minimum_maximum_retention
+spec:
+  severity: high
+  match:
+    target: ["organization/*"]
+  parameters:
+    retention_type: "minimum_maximum"
+    retention_days:
+      - 31
+      - 60
+    exemptions: []

--- a/validator/test/fixtures/bigquery_table_retention/constraints/min_max_retention_one_exemption/data.yaml
+++ b/validator/test/fixtures/bigquery_table_retention/constraints/min_max_retention_one_exemption/data.yaml
@@ -21,9 +21,7 @@ spec:
   match:
     target: ["organization/*"]
   parameters:
-    retention_type: "minimum_maximum"
-    retention_days:
-      - 31
-      - 60
+    minimum_retention_days: 31
+    maximum_retention_days: 60
     exemptions:
       - //bigquery.googleapis.com/projects/forseti-test-110/datasets/my_bq_dataset/tables/my_bq_table

--- a/validator/test/fixtures/bigquery_table_retention/constraints/min_max_retention_one_exemption/data.yaml
+++ b/validator/test/fixtures/bigquery_table_retention/constraints/min_max_retention_one_exemption/data.yaml
@@ -1,0 +1,29 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPBigQueryTableRetentionConstraintV1
+metadata:
+  name: bq_table_minimum_maximum_retention_one_exception
+spec:
+  severity: high
+  match:
+    target: ["organization/*"]
+  parameters:
+    retention_type: "minimum_maximum"
+    retention_days:
+      - 31
+      - 60
+    exemptions:
+      - //bigquery.googleapis.com/projects/forseti-test-110/datasets/my_bq_dataset/tables/my_bq_table

--- a/validator/test/fixtures/bigquery_table_retention/constraints/min_retention_only/data.yaml
+++ b/validator/test/fixtures/bigquery_table_retention/constraints/min_retention_only/data.yaml
@@ -21,7 +21,5 @@ spec:
   match:
     target: ["organization/*"]
   parameters:
-    retention_type: "minimum"
-    retention_days:
-      - 31
+    minimum_retention_days: 31
     exemptions: []

--- a/validator/test/fixtures/bigquery_table_retention/constraints/min_retention_only/data.yaml
+++ b/validator/test/fixtures/bigquery_table_retention/constraints/min_retention_only/data.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPBigQueryTableRetentionConstraintV1
+metadata:
+  name: bq_table_minimum_retention
+spec:
+  severity: high
+  match:
+    target: ["organization/*"]
+  parameters:
+    retention_type: "minimum"
+    retention_days:
+      - 31
+    exemptions: []

--- a/validator/test/fixtures/bigquery_table_retention/constraints/min_retention_only_one_exemption/data.yaml
+++ b/validator/test/fixtures/bigquery_table_retention/constraints/min_retention_only_one_exemption/data.yaml
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPBigQueryTableRetentionConstraintV1
+metadata:
+  name: bq_table_minimum_retention_one_exemption
+spec:
+  severity: high
+  match:
+    target: ["organization/*"]
+  parameters:
+    retention_type: "minimum"
+    retention_days:
+      - 31
+    exemptions:
+      - //bigquery.googleapis.com/projects/forseti-test-110/datasets/my_bq_dataset/tables/my_bq_table

--- a/validator/test/fixtures/bigquery_table_retention/constraints/min_retention_only_one_exemption/data.yaml
+++ b/validator/test/fixtures/bigquery_table_retention/constraints/min_retention_only_one_exemption/data.yaml
@@ -21,8 +21,6 @@ spec:
   match:
     target: ["organization/*"]
   parameters:
-    retention_type: "minimum"
-    retention_days:
-      - 31
+    minimum_retention_days: 31
     exemptions:
       - //bigquery.googleapis.com/projects/forseti-test-110/datasets/my_bq_dataset/tables/my_bq_table


### PR DESCRIPTION
BigQuery Table constraint for #271

This PR creates a BigQuery Table Retention constraint that checks for the retention policy of a BigQuery table and compares the user defined number of days the retention of a BigQuery table should be against what it actually is, utilizing the creationTime and expirationTime fields found in the BigQuery table resource.

This constraint provides the following features:

1. **minimum_retention_days**
- minimum_retention_days identifies the minimum number of days the retention of a BigQuery table should be. 
  - Generate a violation if the resource retention is less than the minimum number of retention days allowed.
2. **maximum_retention_days**
- maximum_retention_days identifies the maximum number of days the retention of a BigQuery table can be.
  - Generate a violation if the resource retention is greater than the maximum number of retention days allowed.
  - Generate a violation if expirationTime does not exist when looking at the maximum retention.
3. **Exemptions**
- BigQuery tables to exempt from retention restriction.

NOTE: Can use values for both minimum_retention_days and maximum_retention_days to define a range of days that the resource retention should be within.


Also included in this PR:

- Sample constraint
- Tests