### PR TITLE
Constraint for GKE Shielded Nodes

### DIFF
--- a/policies/templates/gcp_gke_enable_shielded_nodes_v1.yaml
+++ b/policies/templates/gcp_gke_enable_shielded_nodes_v1.yaml
@@ -1,0 +1,100 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Check to see if GKE legacy endpoints is disabled.
+# https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#protect_node_metadata
+
+apiVersion: templates.gatekeeper.sh/v1alpha1
+kind: ConstraintTemplate
+metadata:
+  name: gcp-gke-enable-shielded-nodes-v1
+spec:
+  crd:
+    spec:
+      names:
+        kind: GCPGKEEnableShieldedNodesConstraintV1
+      validation:
+        openAPIV3Schema:
+          properties: {}
+  targets:
+    validation.gcp.forsetisecurity.org:
+      rego: | #INLINE("validator/gke_enable_shielded_nodes.rego")
+            #
+            # Copyright 2019 Google LLC
+            #
+            # Licensed under the Apache License, Version 2.0 (the "License");
+            # you may not use this file except in compliance with the License.
+            # You may obtain a copy of the License at
+            #
+            #      http://www.apache.org/licenses/LICENSE-2.0
+            #
+            # Unless required by applicable law or agreed to in writing, software
+            # distributed under the License is distributed on an "AS IS" BASIS,
+            # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+            # See the License for the specific language governing permissions and
+            # limitations under the License.
+            #
+            
+            package templates.gcp.GCPGKEEnableShieldedNodesConstraintV1
+            
+            import data.validator.gcp.lib as lib
+            
+            deny[{
+            	"msg": message,
+            	"details": metadata,
+            }] {
+            	constraint := input.constraint
+            	asset := input.asset
+            	asset.asset_type == "container.googleapis.com/Cluster"
+            
+            	cluster := asset.resource.data
+            	node_pools := lib.get_default(cluster, "nodePools", [])
+            	node_pool := node_pools[_]
+            
+            	# We fail if either the cluster doesn't have shielded vms, or
+            	# one of the node pools doesn't have the proper settings.
+            	cluster_shielded_nodes(cluster, node_pool)
+            
+            	message := sprintf("Cluster %v doesn't use shielded VMs with integrity and secure boot in node pool %v.", [asset.name, node_pool.name])
+            	metadata := {"resource": asset.name}
+            }
+            
+            ###########################
+            # Rule Utilities
+            ###########################
+            
+            # Checks the Shielded Nodes setting in the cluster configuration.
+            cluster_shielded_nodes(cluster, node_pool) {
+            	shielded_nodes := lib.get_default(cluster, "shieldedNodes", {})
+            	enabled := lib.get_default(shielded_nodes, "enabled", false)
+            	enabled == false
+            }
+            
+            # Checks that all shielded nodes options are enabled for all node pools.
+            cluster_shielded_nodes(cluster, node_pool) {
+            	single_pool := lib.get_default(node_pool, "config", {})
+            	shieldedInstanceConfig := lib.get_default(single_pool, "shieldedInstanceConfig", {})
+            	integrity_monitoring := lib.get_default(shieldedInstanceConfig, "enableIntegrityMonitoring", false)
+            	secure_boot := lib.get_default(shieldedInstanceConfig, "enableSecureBoot", false)
+            	node_pool_check(integrity_monitoring, secure_boot)
+            }
+            
+            node_pool_check(integrity_monitoring, secure_boot) {
+            	integrity_monitoring == false
+            }
+            
+            node_pool_check(integrity_monitoring, secure_boot) {
+            	secure_boot == false
+            }
+            #ENDINLINE

--- a/policies/templates/gcp_gke_enable_shielded_nodes_v1.yaml
+++ b/policies/templates/gcp_gke_enable_shielded_nodes_v1.yaml
@@ -64,7 +64,7 @@ spec:
             
             	# We fail if either the cluster doesn't have shielded vms, or
             	# one of the node pools doesn't have the proper settings.
-            	cluster_shielded_nodes(cluster, node_pool)
+            	cluster_shielded_nodes_disabled(cluster, node_pool)
             
             	message := sprintf("Cluster %v doesn't use shielded VMs with integrity and secure boot in node pool %v.", [asset.name, node_pool.name])
             	metadata := {"resource": asset.name}
@@ -75,26 +75,26 @@ spec:
             ###########################
             
             # Checks the Shielded Nodes setting in the cluster configuration.
-            cluster_shielded_nodes(cluster, node_pool) {
+            cluster_shielded_nodes_disabled(cluster, node_pool) {
             	shielded_nodes := lib.get_default(cluster, "shieldedNodes", {})
             	enabled := lib.get_default(shielded_nodes, "enabled", false)
             	enabled == false
             }
             
             # Checks that all shielded nodes options are enabled for all node pools.
-            cluster_shielded_nodes(cluster, node_pool) {
+            cluster_shielded_nodes_disabled(cluster, node_pool) {
             	single_pool := lib.get_default(node_pool, "config", {})
             	shieldedInstanceConfig := lib.get_default(single_pool, "shieldedInstanceConfig", {})
             	integrity_monitoring := lib.get_default(shieldedInstanceConfig, "enableIntegrityMonitoring", false)
             	secure_boot := lib.get_default(shieldedInstanceConfig, "enableSecureBoot", false)
-            	node_pool_check(integrity_monitoring, secure_boot)
+            	node_pool_has_insufficient_configuration(integrity_monitoring, secure_boot)
             }
             
-            node_pool_check(integrity_monitoring, secure_boot) {
+            node_pool_has_insufficient_configuration(integrity_monitoring, secure_boot) {
             	integrity_monitoring == false
             }
             
-            node_pool_check(integrity_monitoring, secure_boot) {
+            node_pool_has_insufficient_configuration(integrity_monitoring, secure_boot) {
             	secure_boot == false
             }
             #ENDINLINE

--- a/samples/gke_enable_shielded_nodes.yaml
+++ b/samples/gke_enable_shielded_nodes.yaml
@@ -1,0 +1,24 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPGKEEnableShieldedNodesConstraintV1
+metadata:
+  name: enable_gke_shielded_nodes
+spec:
+  severity: high
+  match:
+    gcp:
+      target: ["organization/*"]
+  parameters: {}

--- a/validator/gke_enable_shielded_nodes.rego
+++ b/validator/gke_enable_shielded_nodes.rego
@@ -32,7 +32,7 @@ deny[{
 
 	# We fail if either the cluster doesn't have shielded vms, or
 	# one of the node pools doesn't have the proper settings.
-	cluster_shielded_nodes(cluster, node_pool)
+	cluster_shielded_nodes_disabled(cluster, node_pool)
 
 	message := sprintf("Cluster %v doesn't use shielded VMs with integrity and secure boot in node pool %v.", [asset.name, node_pool.name])
 	metadata := {"resource": asset.name}
@@ -43,25 +43,25 @@ deny[{
 ###########################
 
 # Checks the Shielded Nodes setting in the cluster configuration.
-cluster_shielded_nodes(cluster, node_pool) {
+cluster_shielded_nodes_disabled(cluster, node_pool) {
 	shielded_nodes := lib.get_default(cluster, "shieldedNodes", {})
 	enabled := lib.get_default(shielded_nodes, "enabled", false)
 	enabled == false
 }
 
 # Checks that all shielded nodes options are enabled for all node pools.
-cluster_shielded_nodes(cluster, node_pool) {
+cluster_shielded_nodes_disabled(cluster, node_pool) {
 	single_pool := lib.get_default(node_pool, "config", {})
 	shieldedInstanceConfig := lib.get_default(single_pool, "shieldedInstanceConfig", {})
 	integrity_monitoring := lib.get_default(shieldedInstanceConfig, "enableIntegrityMonitoring", false)
 	secure_boot := lib.get_default(shieldedInstanceConfig, "enableSecureBoot", false)
-	node_pool_check(integrity_monitoring, secure_boot)
+	node_pool_has_insufficient_configuration(integrity_monitoring, secure_boot)
 }
 
-node_pool_check(integrity_monitoring, secure_boot) {
+node_pool_has_insufficient_configuration(integrity_monitoring, secure_boot) {
 	integrity_monitoring == false
 }
 
-node_pool_check(integrity_monitoring, secure_boot) {
+node_pool_has_insufficient_configuration(integrity_monitoring, secure_boot) {
 	secure_boot == false
 }

--- a/validator/gke_enable_shielded_nodes.rego
+++ b/validator/gke_enable_shielded_nodes.rego
@@ -1,0 +1,67 @@
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package templates.gcp.GCPGKEEnableShieldedNodesConstraintV1
+
+import data.validator.gcp.lib as lib
+
+deny[{
+	"msg": message,
+	"details": metadata,
+}] {
+	constraint := input.constraint
+	asset := input.asset
+	asset.asset_type == "container.googleapis.com/Cluster"
+
+	cluster := asset.resource.data
+	node_pools := lib.get_default(cluster, "nodePools", [])
+	node_pool := node_pools[_]
+
+	# We fail if either the cluster doesn't have shielded vms, or
+	# one of the node pools doesn't have the proper settings.
+	cluster_shielded_nodes(cluster, node_pool)
+
+	message := sprintf("Cluster %v doesn't use shielded VMs with integrity and secure boot in node pool %v.", [asset.name, node_pool.name])
+	metadata := {"resource": asset.name}
+}
+
+###########################
+# Rule Utilities
+###########################
+
+# Checks the Shielded Nodes setting in the cluster configuration.
+cluster_shielded_nodes(cluster, node_pool) {
+	shielded_nodes := lib.get_default(cluster, "shieldedNodes", {})
+	enabled := lib.get_default(shielded_nodes, "enabled", false)
+	enabled == false
+}
+
+# Checks that all shielded nodes options are enabled for all node pools.
+cluster_shielded_nodes(cluster, node_pool) {
+	single_pool := lib.get_default(node_pool, "config", {})
+	shieldedInstanceConfig := lib.get_default(single_pool, "shieldedInstanceConfig", {})
+	integrity_monitoring := lib.get_default(shieldedInstanceConfig, "enableIntegrityMonitoring", false)
+	secure_boot := lib.get_default(shieldedInstanceConfig, "enableSecureBoot", false)
+	node_pool_check(integrity_monitoring, secure_boot)
+}
+
+node_pool_check(integrity_monitoring, secure_boot) {
+	integrity_monitoring == false
+}
+
+node_pool_check(integrity_monitoring, secure_boot) {
+	secure_boot == false
+}

--- a/validator/gke_enable_shielded_nodes_test.rego
+++ b/validator/gke_enable_shielded_nodes_test.rego
@@ -1,0 +1,47 @@
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package templates.gcp.GCPGKEEnableShieldedNodesConstraintV1
+
+import data.validator.gcp.lib as lib
+
+all_violations[violation] {
+	resource := data.test.fixtures.gke_enable_shielded_nodes.assets[_]
+	constraint := data.test.fixtures.gke_enable_shielded_nodes.constraints.enable_shielded_nodes
+
+	issues := deny with input.asset as resource
+		 with input.constraint as constraint
+
+	violation := issues[_]
+}
+
+# Tests that the nodes with shielded nodes disabled at the cluster are detected
+test_disabled_shielded_nodes {
+	violation := all_violations[_]
+	resource_names := {x | x = violation.details.resource}
+
+	trace(sprintf("Resource not expected: %s", [resource_names]))
+	not resource_names["//container.googleapicom/projects/transfer-repo/zones/us-central1-c/clusters/shielded-enabled"]
+	resource_in_violation(resource_names)
+}
+
+resource_in_violation(resource_names) {
+	resource_names["//container.googleapis.com/projects/transfer-repo/zones/us-central1-c/clusters/shielded-nodes-disabled"]
+}
+
+resouce_in_violation(resource_names) {
+	resource_names["//container.googleapis.com/projects/transfer-repo/zones/us-central1-c/clusters/shielded-nodes-enabled-noboot"]
+}

--- a/validator/gke_enable_shielded_nodes_test.rego
+++ b/validator/gke_enable_shielded_nodes_test.rego
@@ -16,32 +16,19 @@
 
 package templates.gcp.GCPGKEEnableShieldedNodesConstraintV1
 
+import data.test.fixtures.gke_enable_shielded_nodes.assets as fixture_assets
+import data.test.fixtures.gke_enable_shielded_nodes.constraints as fixture_constraints
 import data.validator.gcp.lib as lib
 
-all_violations[violation] {
-	resource := data.test.fixtures.gke_enable_shielded_nodes.assets[_]
-	constraint := data.test.fixtures.gke_enable_shielded_nodes.constraints.enable_shielded_nodes
+import data.validator.test_utils as test_utils
 
-	issues := deny with input.asset as resource
-		 with input.constraint as constraint
+template_name := "GCPGKEEnableShieldedNodesConstraintV1"
 
-	violation := issues[_]
-}
-
-# Tests that the nodes with shielded nodes disabled at the cluster are detected
 test_disabled_shielded_nodes {
-	violation := all_violations[_]
-	resource_names := {x | x = violation.details.resource}
+	expected_resource_names = {
+		"//container.googleapis.com/projects/transfer-repo/zones/us-central1-c/clusters/shielded-nodes-disabled",
+		"//container.googleapis.com/projects/transfer-repo/zones/us-central1-c/clusters/shielded-nodes-enabled-noboot",
+	}
 
-	trace(sprintf("Resource not expected: %s", [resource_names]))
-	not resource_names["//container.googleapicom/projects/transfer-repo/zones/us-central1-c/clusters/shielded-enabled"]
-	resource_in_violation(resource_names)
-}
-
-resource_in_violation(resource_names) {
-	resource_names["//container.googleapis.com/projects/transfer-repo/zones/us-central1-c/clusters/shielded-nodes-disabled"]
-}
-
-resouce_in_violation(resource_names) {
-	resource_names["//container.googleapis.com/projects/transfer-repo/zones/us-central1-c/clusters/shielded-nodes-enabled-noboot"]
+	test_utils.check_test_violations(fixture_assets, [fixture_constraints.enable_shielded_nodes], template_name, expected_resource_names)
 }

--- a/validator/test/fixtures/gke_enable_shielded_nodes/assets/data.json
+++ b/validator/test/fixtures/gke_enable_shielded_nodes/assets/data.json
@@ -1,0 +1,372 @@
+[
+  {
+    "name": "//container.googleapis.com/projects/transfer-repo/zones/us-central1-c/clusters/shielded-nodes-enabled",
+    "asset_type": "container.googleapis.com/Cluster",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://container.googleapis.com/$discovery/rest",
+      "discovery_name": "Cluster",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/321240941520",
+      "data": {
+        "addonsConfig": {
+          "horizontalPodAutoscaling": {},
+          "httpLoadBalancing": {},
+          "kubernetesDashboard": {
+            "disabled": true
+          },
+          "networkPolicyConfig": {
+            "disabled": true
+          }
+        },
+        "authenticatorGroupsConfig": {},
+        "clusterIpv4Cidr": "10.56.0.0/14",
+        "createTime": "2020-03-05T17:35:40+00:00",
+        "currentMasterVersion": "1.14.10-gke.17",
+        "currentNodeCount": 3,
+        "currentNodeVersion": "1.14.10-gke.17",
+        "databaseEncryption": {
+          "state": "DECRYPTED"
+        },
+        "defaultMaxPodsConstraint": {
+          "maxPodsPerNode": "110"
+        },
+        "endpoint": "35.188.34.99",
+        "initialClusterVersion": "1.14.10-gke.17",
+        "instanceGroupUrls": [
+          "https://www.googleapis.com/compute/v1/projects/transfer-repo/zones/us-central1-c/instanceGroupManagers/gke-shielded-nodes-enabl-default-pool-86295a0a-grp"
+        ],
+        "ipAllocationPolicy": {
+          "clusterIpv4Cidr": "10.56.0.0/14",
+          "clusterIpv4CidrBlock": "10.56.0.0/14",
+          "clusterSecondaryRangeName": "gke-shielded-nodes-enabled-pods-fd0a23a7",
+          "servicesIpv4Cidr": "10.0.0.0/20",
+          "servicesIpv4CidrBlock": "10.0.0.0/20",
+          "servicesSecondaryRangeName": "gke-shielded-nodes-enabled-services-fd0a23a7",
+          "useIpAliases": true
+        },
+        "labelFingerprint": "a9dc16a7",
+        "legacyAbac": {},
+        "location": "us-central1-c",
+        "locations": [
+          "us-central1-c"
+        ],
+        "loggingService": "logging.googleapis.com/kubernetes",
+        "maintenancePolicy": {
+          "resourceVersion": "e3b0c442"
+        },
+        "masterAuthorizedNetworksConfig": {},
+        "monitoringService": "monitoring.googleapis.com/kubernetes",
+        "name": "shielded-nodes-enabled",
+        "network": "default",
+        "networkConfig": {
+          "network": "projects/transfer-repo/global/networks/default",
+          "subnetwork": "projects/transfer-repo/regions/us-central1/subnetworks/default"
+        },
+        "networkPolicy": {},
+        "nodePools": [
+          {
+            "autoscaling": {},
+            "config": {
+              "diskSizeGb": 100,
+              "diskType": "pd-standard",
+              "imageType": "COS",
+              "machineType": "n1-standard-1",
+              "metadata": {
+                "disable-legacy-endpoints": "true"
+              },
+              "oauthScopes": [
+                "https://www.googleapis.com/auth/devstorage.read_only",
+                "https://www.googleapis.com/auth/logging.write",
+                "https://www.googleapis.com/auth/monitoring",
+                "https://www.googleapis.com/auth/servicecontrol",
+                "https://www.googleapis.com/auth/service.management.readonly",
+                "https://www.googleapis.com/auth/trace.append"
+              ],
+              "serviceAccount": "default",
+              "shieldedInstanceConfig": {
+                "enableIntegrityMonitoring": true,
+                "enableSecureBoot": true
+              }
+            },
+            "initialNodeCount": 3,
+            "instanceGroupUrls": [
+              "https://www.googleapis.com/compute/v1/projects/transfer-repo/zones/us-central1-c/instanceGroupManagers/gke-shielded-nodes-enabl-default-pool-86295a0a-grp"
+            ],
+            "locations": [
+              "us-central1-c"
+            ],
+            "management": {
+              "autoRepair": true,
+              "autoUpgrade": true
+            },
+            "maxPodsConstraint": {
+              "maxPodsPerNode": "110"
+            },
+            "name": "default-pool",
+            "podIpv4CidrSize": 24,
+            "selfLink": "https://container.googleapis.com/v1/projects/transfer-repo/zones/us-central1-c/clusters/shielded-nodes-enabled/nodePools/default-pool",
+            "status": "RUNNING",
+            "version": "1.14.10-gke.17"
+          }
+        ],
+        "selfLink": "https://container.googleapis.com/v1/projects/transfer-repo/zones/us-central1-c/clusters/shielded-nodes-enabled",
+        "servicesIpv4Cidr": "10.0.0.0/20",
+        "shieldedNodes": {
+          "enabled": true
+        },
+        "status": "RUNNING",
+        "subnetwork": "default",
+        "zone": "us-central1-c"
+      }
+    },
+    "ancestors": [
+      "projects/321240941520",
+      "folders/396521612403",
+      "organizations/433637338589"
+    ]
+  },
+  {
+    "name": "//container.googleapis.com/projects/transfer-repo/zones/us-central1-c/clusters/shielded-nodes-disabled",
+    "asset_type": "container.googleapis.com/Cluster",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://container.googleapis.com/$discovery/rest",
+      "discovery_name": "Cluster",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/321240941520",
+      "data": {
+        "addonsConfig": {
+          "horizontalPodAutoscaling": {},
+          "httpLoadBalancing": {},
+          "kubernetesDashboard": {
+            "disabled": true
+          },
+          "networkPolicyConfig": {
+            "disabled": true
+          }
+        },
+        "authenticatorGroupsConfig": {},
+        "clusterIpv4Cidr": "10.60.0.0/14",
+        "createTime": "2020-03-05T17:27:14+00:00",
+        "currentMasterVersion": "1.14.10-gke.17",
+        "currentNodeCount": 3,
+        "currentNodeVersion": "1.14.10-gke.17",
+        "databaseEncryption": {
+          "state": "DECRYPTED"
+        },
+        "defaultMaxPodsConstraint": {
+          "maxPodsPerNode": "110"
+        },
+        "endpoint": "34.69.80.111",
+        "initialClusterVersion": "1.14.10-gke.17",
+        "instanceGroupUrls": [
+          "https://www.googleapis.com/compute/v1/projects/transfer-repo/zones/us-central1-c/instanceGroupManagers/gke-shielded-nodes-disab-default-pool-bfdd437d-grp"
+        ],
+        "ipAllocationPolicy": {
+          "clusterIpv4Cidr": "10.60.0.0/14",
+          "clusterIpv4CidrBlock": "10.60.0.0/14",
+          "clusterSecondaryRangeName": "gke-shielded-nodes-disabled-pods-6e3cfb21",
+          "servicesIpv4Cidr": "10.64.0.0/20",
+          "servicesIpv4CidrBlock": "10.64.0.0/20",
+          "servicesSecondaryRangeName": "gke-shielded-nodes-disabled-services-6e3cfb21",
+          "useIpAliases": true
+        },
+        "labelFingerprint": "a9dc16a7",
+        "legacyAbac": {},
+        "location": "us-central1-c",
+        "locations": [
+          "us-central1-c"
+        ],
+        "loggingService": "logging.googleapis.com/kubernetes",
+        "maintenancePolicy": {
+          "resourceVersion": "e3b0c442"
+        },
+        "masterAuthorizedNetworksConfig": {},
+        "monitoringService": "monitoring.googleapis.com/kubernetes",
+        "name": "shielded-nodes-disabled",
+        "network": "default",
+        "networkConfig": {
+          "network": "projects/transfer-repo/global/networks/default",
+          "subnetwork": "projects/transfer-repo/regions/us-central1/subnetworks/default"
+        },
+        "networkPolicy": {},
+        "nodePools": [
+          {
+            "autoscaling": {},
+            "config": {
+              "diskSizeGb": 100,
+              "diskType": "pd-standard",
+              "imageType": "COS",
+              "machineType": "n1-standard-1",
+              "metadata": {
+                "disable-legacy-endpoints": "true"
+              },
+              "oauthScopes": [
+                "https://www.googleapis.com/auth/cloud-platform"
+              ],
+              "serviceAccount": "gke-cluster@transfer-repo.iam.gserviceaccount.com",
+              "shieldedInstanceConfig": {
+                "enableIntegrityMonitoring": true,
+                "enableSecureBoot": true
+              }
+            },
+            "initialNodeCount": 3,
+            "instanceGroupUrls": [
+              "https://www.googleapis.com/compute/v1/projects/transfer-repo/zones/us-central1-c/instanceGroupManagers/gke-shielded-nodes-disab-default-pool-bfdd437d-grp"
+            ],
+            "locations": [
+              "us-central1-c"
+            ],
+            "management": {
+              "autoRepair": true,
+              "autoUpgrade": true
+            },
+            "maxPodsConstraint": {
+              "maxPodsPerNode": "110"
+            },
+            "name": "default-pool",
+            "podIpv4CidrSize": 24,
+            "selfLink": "https://container.googleapis.com/v1/projects/transfer-repo/zones/us-central1-c/clusters/shielded-nodes-disabled/nodePools/default-pool",
+            "status": "RUNNING",
+            "version": "1.14.10-gke.17"
+          }
+        ],
+        "selfLink": "https://container.googleapis.com/v1/projects/transfer-repo/zones/us-central1-c/clusters/shielded-nodes-disabled",
+        "servicesIpv4Cidr": "10.64.0.0/20",
+        "shieldedNodes": {},
+        "status": "RUNNING",
+        "subnetwork": "default",
+        "zone": "us-central1-c"
+      }
+    },
+    "ancestors": [
+      "projects/321240941520",
+      "folders/396521612403",
+      "organizations/433637338589"
+    ]
+  },
+  {
+    "name": "//container.googleapis.com/projects/transfer-repo/zones/us-central1-c/clusters/shielded-nodes-enabled-noboot",
+    "asset_type": "container.googleapis.com/Cluster",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://container.googleapis.com/$discovery/rest",
+      "discovery_name": "Cluster",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/321240941520",
+      "data": {
+        "addonsConfig": {
+          "horizontalPodAutoscaling": {},
+          "httpLoadBalancing": {},
+          "kubernetesDashboard": {
+            "disabled": true
+          },
+          "networkPolicyConfig": {
+            "disabled": true
+          }
+        },
+        "authenticatorGroupsConfig": {},
+        "clusterIpv4Cidr": "10.56.0.0/14",
+        "createTime": "2020-03-05T17:35:40+00:00",
+        "currentMasterVersion": "1.14.10-gke.17",
+        "currentNodeCount": 3,
+        "currentNodeVersion": "1.14.10-gke.17",
+        "databaseEncryption": {
+          "state": "DECRYPTED"
+        },
+        "defaultMaxPodsConstraint": {
+          "maxPodsPerNode": "110"
+        },
+        "endpoint": "35.188.34.99",
+        "initialClusterVersion": "1.14.10-gke.17",
+        "instanceGroupUrls": [
+          "https://www.googleapis.com/compute/v1/projects/transfer-repo/zones/us-central1-c/instanceGroupManagers/gke-shielded-nodes-enabl-default-pool-86295a0a-grp"
+        ],
+        "ipAllocationPolicy": {
+          "clusterIpv4Cidr": "10.56.0.0/14",
+          "clusterIpv4CidrBlock": "10.56.0.0/14",
+          "clusterSecondaryRangeName": "gke-shielded-nodes-enabled-pods-fd0a23a7",
+          "servicesIpv4Cidr": "10.0.0.0/20",
+          "servicesIpv4CidrBlock": "10.0.0.0/20",
+          "servicesSecondaryRangeName": "gke-shielded-nodes-enabled-services-fd0a23a7",
+          "useIpAliases": true
+        },
+        "labelFingerprint": "a9dc16a7",
+        "legacyAbac": {},
+        "location": "us-central1-c",
+        "locations": [
+          "us-central1-c"
+        ],
+        "loggingService": "logging.googleapis.com/kubernetes",
+        "maintenancePolicy": {
+          "resourceVersion": "e3b0c442"
+        },
+        "masterAuthorizedNetworksConfig": {},
+        "monitoringService": "monitoring.googleapis.com/kubernetes",
+        "name": "shielded-nodes-enabled",
+        "network": "default",
+        "networkConfig": {
+          "network": "projects/transfer-repo/global/networks/default",
+          "subnetwork": "projects/transfer-repo/regions/us-central1/subnetworks/default"
+        },
+        "networkPolicy": {},
+        "nodePools": [
+          {
+            "autoscaling": {},
+            "config": {
+              "diskSizeGb": 100,
+              "diskType": "pd-standard",
+              "imageType": "COS",
+              "machineType": "n1-standard-1",
+              "metadata": {
+                "disable-legacy-endpoints": "true"
+              },
+              "oauthScopes": [
+                "https://www.googleapis.com/auth/devstorage.read_only",
+                "https://www.googleapis.com/auth/logging.write",
+                "https://www.googleapis.com/auth/monitoring",
+                "https://www.googleapis.com/auth/servicecontrol",
+                "https://www.googleapis.com/auth/service.management.readonly",
+                "https://www.googleapis.com/auth/trace.append"
+              ],
+              "serviceAccount": "default",
+              "shieldedInstanceConfig": {
+                "enableIntegrityMonitoring": true
+              }
+            },
+            "initialNodeCount": 3,
+            "instanceGroupUrls": [
+              "https://www.googleapis.com/compute/v1/projects/transfer-repo/zones/us-central1-c/instanceGroupManagers/gke-shielded-nodes-enabl-default-pool-86295a0a-grp"
+            ],
+            "locations": [
+              "us-central1-c"
+            ],
+            "management": {
+              "autoRepair": true,
+              "autoUpgrade": true
+            },
+            "maxPodsConstraint": {
+              "maxPodsPerNode": "110"
+            },
+            "name": "default-pool",
+            "podIpv4CidrSize": 24,
+            "selfLink": "https://container.googleapis.com/v1/projects/transfer-repo/zones/us-central1-c/clusters/shielded-nodes-enabled/nodePools/default-pool",
+            "status": "RUNNING",
+            "version": "1.14.10-gke.17"
+          }
+        ],
+        "selfLink": "https://container.googleapis.com/v1/projects/transfer-repo/zones/us-central1-c/clusters/shielded-nodes-enabled",
+        "servicesIpv4Cidr": "10.0.0.0/20",
+        "shieldedNodes": {
+          "enabled": true
+        },
+        "status": "RUNNING",
+        "subnetwork": "default",
+        "zone": "us-central1-c"
+      }
+    },
+    "ancestors": [
+      "projects/321240941520",
+      "folders/396521612403",
+      "organizations/433637338589"
+    ]
+  }
+]

--- a/validator/test/fixtures/gke_enable_shielded_nodes/constraints/enable_shielded_nodes/data.yaml
+++ b/validator/test/fixtures/gke_enable_shielded_nodes/constraints/enable_shielded_nodes/data.yaml
@@ -1,0 +1,24 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPGKEEnableShieldedNodesConstraintV1
+metadata:
+  name: enable_gke_shielded_nodes
+spec:
+  severity: high
+  match:
+    gcp:
+      target: ["organization/*"]
+  parameters: {}


### PR DESCRIPTION
The constraint enforces that GKE clusters are created with shielded nodes, and that both secure boot and integrity logging are enabled on all node pools.