### PR TITLE
Revert "Updating opa version to 0.17.2"

### DIFF
--- a/cloudbuild/Dockerfile
+++ b/cloudbuild/Dockerfile
@@ -6,7 +6,7 @@ FROM debian
 
 RUN apt-get update && apt-get install -y build-essential curl python3 python3-pip
 RUN pip3 install pyyaml
-RUN curl -L -o /usr/local/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.17.2/opa_linux_amd64 && \
+RUN curl -L -o /usr/local/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.16.0/opa_linux_amd64 && \
   chmod 755 /usr/local/bin/opa
 
 ENTRYPOINT ["make"]


### PR DESCRIPTION
Reverts forseti-security/policy-library#279 back to 0.16.0