### PR TITLE
Update GCP compute network interface whitelist template

### DIFF
--- a/policies/templates/gcp_compute_network_interface_whitelist_v1.yaml
+++ b/policies/templates/gcp_compute_network_interface_whitelist_v1.yaml
@@ -47,11 +47,11 @@ spec:
             # See the License for the specific language governing permissions and
             # limitations under the License.
             #
-            
+
             package templates.gcp.GCPComputeNetworkInterfaceWhitelistConstraintV1
-            
+
             import data.validator.gcp.lib as lib
-            
+
             deny[{
             	"msg": message,
             	"details": metadata,
@@ -59,26 +59,26 @@ spec:
             	constraint := input.constraint
             	asset := input.asset
             	asset.asset_type == "compute.googleapis.com/Instance"
-            
+
             	lib.get_constraint_params(input.constraint, params)
-            
+
             	instance := asset.resource.data
-            
-            	interfaces := lib.get_default(instance, "networkInterface", [])
+
+            	interfaces := lib.get_default(instance, "networkInterfaces", [])
             	interface := interfaces[_]
             	full_network_uri := interface.network
-            
+
             	whitelist := lib.get_default(params, "whitelist", [])
             	allowed_networks := {n | n = whitelist[_]}
-            
-            	access_configs := lib.get_default(interface, "accessConfig", [])
-            
+
+            	access_configs := lib.get_default(interface, "accessConfigs", [])
+
             	is_external_network := count(access_configs) > 0
             	is_network_whitelisted := count({full_network_uri} - allowed_networks) == 0
-            
+
             	is_external_network == true
             	is_network_whitelisted == false
-            
+
             	message := sprintf("Compute instance %v has interface %v with invalid access configuration.", [asset.name, interface.name])
             	metadata := {"resource": asset.name}
             }

--- a/validator/compute_network_interface_whitelist.rego
+++ b/validator/compute_network_interface_whitelist.rego
@@ -30,14 +30,14 @@ deny[{
 
 	instance := asset.resource.data
 
-	interfaces := lib.get_default(instance, "networkInterface", [])
+	interfaces := lib.get_default(instance, "networkInterfaces", [])
 	interface := interfaces[_]
 	full_network_uri := interface.network
 
 	whitelist := lib.get_default(params, "whitelist", [])
 	allowed_networks := {n | n = whitelist[_]}
 
-	access_configs := lib.get_default(interface, "accessConfig", [])
+	access_configs := lib.get_default(interface, "accessConfigs", [])
 
 	is_external_network := count(access_configs) > 0
 	is_network_whitelisted := count({full_network_uri} - allowed_networks) == 0

--- a/validator/test/fixtures/compute_network_interface_whitelist/assets/data.json
+++ b/validator/test/fixtures/compute_network_interface_whitelist/assets/data.json
@@ -13,14 +13,14 @@
                 "creationTimestamp": "2018-11-01T12:44:57.303-07:00",
                 "deletionProtection": false,
                 "description": "InstanceTemplate created for Dataflow job: 2018-10-02_12_46_57-16714086278907465014",
-                "disk": [
+                "disks": [
                     {
                         "autoDelete": true,
                         "boot": true,
                         "deviceName": "persistent-disk-0",
                         "index": 0,
                         "interface": "SCSI",
-                        "license": [
+                        "licenses": [
                             "https://www.googleapis.com/compute/v1/projects/clouddataflow-readonly/global/licenses/dataflow-owned-resource",
                             "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/licenses/cos"
                         ],
@@ -39,18 +39,18 @@
                 },
                 "machineType": "https://www.googleapis.com/compute/v1/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/machineTypes/n1-standard-4",
                 "name": "valid-instance-8hz5",
-                "networkInterface": [
+                "networkInterfaces": [
                     {
-                        "accessConfig": [
+                        "accessConfigs": [
                             {
-                                "externalIp": "35.226.29.59",
+                                "natIP": "35.226.29.59",
                                 "name": "EXTERNAL NAT",
                                 "networkTier": "PREMIUM",
                                 "type": "ONE_TO_ONE_NAT"
                             }
                         ],
                         "fingerprint": "BZYSgscuzgc=",
-                        "ipAddress": "10.128.0.3",
+                        "networkIP": "10.128.0.3",
                         "name": "nic0",
                         "network": "https://www.googleapis.com/compute/v1/projects/vpc-sc-pub-sub-billing-alerts/global/networks/default1",
                         "subnetwork": "https://www.googleapis.com/compute/v1/projects/vpc-sc-pub-sub-billing-alerts/regions/us-central1/subnetworks/default"
@@ -62,10 +62,10 @@
                     "preemptible": false
                 },
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/instances/valid-instance-8hz5",
-                "serviceAccount": [
+                "serviceAccounts": [
                     {
                         "email": "216968792402-compute@developer.gserviceaccount.com",
-                        "scope": [
+                        "scopes": [
                             "https://www.googleapis.com/auth/any-api",
                             "https://www.googleapis.com/auth/bigquery",
                             "https://www.googleapis.com/auth/cloud-platform",
@@ -106,14 +106,14 @@
                 "creationTimestamp": "2018-11-01T12:44:57.303-07:00",
                 "deletionProtection": false,
                 "description": "InstanceTemplate created for Dataflow job: 2018-10-02_12_46_57-16714086278907465014",
-                "disk": [
+                "disks": [
                     {
                         "autoDelete": true,
                         "boot": true,
                         "deviceName": "persistent-disk-0",
                         "index": 0,
                         "interface": "SCSI",
-                        "license": [
+                        "licenses": [
                             "https://www.googleapis.com/compute/v1/projects/clouddataflow-readonly/global/licenses/dataflow-owned-resource",
                             "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/licenses/cos"
                         ],
@@ -132,18 +132,18 @@
                 },
                 "machineType": "https://www.googleapis.com/compute/v1/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/machineTypes/n1-standard-4",
                 "name": "valid-instance-8hz5",
-                "networkInterface": [
+                "networkInterfaces": [
                     {
-                        "accessConfig": [
+                        "accessConfigs": [
                             {
-                                "externalIp": "35.226.29.59",
+                                "natIP": "35.226.29.59",
                                 "name": "EXTERNAL NAT",
                                 "networkTier": "PREMIUM",
                                 "type": "ONE_TO_ONE_NAT"
                             }
                         ],
                         "fingerprint": "BZYSgscuzgc=",
-                        "ipAddress": "10.128.0.3",
+                        "networkIP": "10.128.0.3",
                         "name": "nic0",
                         "network": "https://www.googleapis.com/compute/v1/projects/vpc-sc-pub-sub-billing-alerts/global/networks/default2",
                         "subnetwork": "https://www.googleapis.com/compute/v1/projects/vpc-sc-pub-sub-billing-alerts/regions/us-central1/subnetworks/default"
@@ -155,10 +155,10 @@
                     "preemptible": false
                 },
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/vpc-sc-pub-sub-billing-alerts/zones/us-central1-b/instances/valid-instance-8hz5",
-                "serviceAccount": [
+                "serviceAccounts": [
                     {
                         "email": "216968792402-compute@developer.gserviceaccount.com",
-                        "scope": [
+                        "scopes": [
                             "https://www.googleapis.com/auth/any-api",
                             "https://www.googleapis.com/auth/bigquery",
                             "https://www.googleapis.com/auth/cloud-platform",


### PR DESCRIPTION
Update GCP compute network interface whitelist template to use networkInterfaces and accessConfigs fields. Updated test asset data to reflect the change that will go live on March 10th. This change will also work with existin CAI exports generated after the CAI field change went live in September.

Resolves #290 