### PR TITLE
GKE Workload Identity constraint.

### DIFF
--- a/policies/templates/gcp_gke_enable_workload_identity_v1.yaml
+++ b/policies/templates/gcp_gke_enable_workload_identity_v1.yaml
@@ -1,0 +1,86 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Check to see if GKE stackdriver logging is enabled
+# https://cloud.google.com/logging/kubernetes-engine/
+
+apiVersion: templates.gatekeeper.sh/v1alpha1
+kind: ConstraintTemplate
+metadata:
+  name: gcp-gke-enable-workload-identity-v1
+spec:
+  crd:
+    spec:
+      names:
+        kind: GCPGKEEnableWorkloadIdentityConstraintV1
+      validation:
+        openAPIV3Schema:
+          properties: {}
+  targets:
+    validation.gcp.forsetisecurity.org:
+      rego: | #INLINE("validator/gke_enable_workload_identity.rego")
+            #
+            # Copyright 2019 Google LLC
+            #
+            # Licensed under the Apache License, Version 2.0 (the "License");
+            # you may not use this file except in compliance with the License.
+            # You may obtain a copy of the License at
+            #
+            #      http://www.apache.org/licenses/LICENSE-2.0
+            #
+            # Unless required by applicable law or agreed to in writing, software
+            # distributed under the License is distributed on an "AS IS" BASIS,
+            # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+            # See the License for the specific language governing permissions and
+            # limitations under the License.
+            #
+            
+            package templates.gcp.GCPGKEEnableWorkloadIdentityConstraintV1
+            
+            import data.validator.gcp.lib as lib
+            
+            deny[{
+            	"msg": message,
+            	"details": metadata,
+            }] {
+            	constraint := input.constraint
+            	asset := input.asset
+            	asset.asset_type == "container.googleapis.com/Cluster"
+            
+            	cluster := asset.resource.data
+            	workload_identity_disabled(cluster)
+            
+            	message := sprintf("Workload identity is disabled in cluster %v.", [asset.name])
+            	metadata := {"resource": asset.name}
+            }
+            
+            ###########################
+            # Rule Utilities
+            ###########################
+            workload_identity_disabled(cluster) {
+            	workload_identity_config := lib.get_default(cluster, "workloadIdentityConfig", {})
+            	not workload_identity_field_exists(workload_identity_config)
+            }
+            
+            workload_identity_field_exists(workload_identity_config) {
+            	lib.has_field(workload_identity_config, "workloadPool")
+            }
+            
+            # The Beta version of the API uses the identityNamespace field instead
+            # It won't appear in Cloud Asset Inventory data, but it will appear
+            # in conversions from Terraform Validator (using the Beta provider).
+            workload_identity_field_exists(workload_identity_config) {
+            	lib.has_field(workload_identity_config, "identityNamespace")
+            }
+            #ENDINLINE

--- a/samples/gke_enable_workload_identity.yaml
+++ b/samples/gke_enable_workload_identity.yaml
@@ -1,0 +1,26 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPGKEEnableWorkloadIdentityConstraintV1
+metadata:
+  name: enable_gke_workload_identity
+  annotations:
+    description: Ensure Workload Identity is enabled on a GKE cluster
+spec:
+  severity: high
+  match:
+    gcp:
+      target: ["organization/*"]
+  parameters: {}

--- a/validator/gke_enable_workload_identity.rego
+++ b/validator/gke_enable_workload_identity.rego
@@ -1,0 +1,53 @@
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package templates.gcp.GCPGKEEnableWorkloadIdentityConstraintV1
+
+import data.validator.gcp.lib as lib
+
+deny[{
+	"msg": message,
+	"details": metadata,
+}] {
+	constraint := input.constraint
+	asset := input.asset
+	asset.asset_type == "container.googleapis.com/Cluster"
+
+	cluster := asset.resource.data
+	workload_identity_disabled(cluster)
+
+	message := sprintf("Workload identity is disabled in cluster %v.", [asset.name])
+	metadata := {"resource": asset.name}
+}
+
+###########################
+# Rule Utilities
+###########################
+workload_identity_disabled(cluster) {
+	workload_identity_config := lib.get_default(cluster, "workloadIdentityConfig", {})
+	not workload_identity_field_exists(workload_identity_config)
+}
+
+workload_identity_field_exists(workload_identity_config) {
+	lib.has_field(workload_identity_config, "workloadPool")
+}
+
+# The Beta version of the API uses the identityNamespace field instead
+# It won't appear in Cloud Asset Inventory data, but it will appear
+# in conversions from Terraform Validator (using the Beta provider).
+workload_identity_field_exists(workload_identity_config) {
+	lib.has_field(workload_identity_config, "identityNamespace")
+}

--- a/validator/gke_enable_workload_identity_test.rego
+++ b/validator/gke_enable_workload_identity_test.rego
@@ -1,0 +1,31 @@
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package templates.gcp.GCPGKEEnableWorkloadIdentityConstraintV1
+
+import data.test.fixtures.gke_enable_workload_identity.assets as fixture_assets
+import data.test.fixtures.gke_enable_workload_identity.constraints as fixture_constraints
+import data.validator.gcp.lib as lib
+
+import data.validator.test_utils as test_utils
+
+template_name := "GCPGKEEnableWorkloadIdentityConstraintV1"
+
+test_disabled_workload_identity {
+	expected_resource_names = {"//container.googleapis.com/projects/testproject/zones/us-central1-c/clusters/workloadidentity-disabled"}
+
+	test_utils.check_test_violations(fixture_assets, [fixture_constraints.enable_gke_workload_identity], template_name, expected_resource_names)
+}

--- a/validator/test/fixtures/gke_enable_workload_identity/assets/data.json
+++ b/validator/test/fixtures/gke_enable_workload_identity/assets/data.json
@@ -1,0 +1,383 @@
+[
+  {
+    "name": "//container.googleapis.com/projects/testproject/zones/us-central1-c/clusters/workloadidentity-enabled",
+    "asset_type": "container.googleapis.com/Cluster",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://container.googleapis.com/$discovery/rest",
+      "discovery_name": "Cluster",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/1111111111",
+      "data": {
+        "addonsConfig": {
+          "horizontalPodAutoscaling": {},
+          "httpLoadBalancing": {},
+          "kubernetesDashboard": {
+            "disabled": true
+          },
+          "networkPolicyConfig": {
+            "disabled": true
+          }
+        },
+        "authenticatorGroupsConfig": {},
+        "clusterIpv4Cidr": "10.32.0.0/14",
+        "createTime": "2020-03-07T04:23:46+00:00",
+        "currentMasterVersion": "1.14.10-gke.17",
+        "currentNodeCount": 3,
+        "currentNodeVersion": "1.14.10-gke.17",
+        "databaseEncryption": {
+          "state": "DECRYPTED"
+        },
+        "defaultMaxPodsConstraint": {
+          "maxPodsPerNode": "110"
+        },
+        "endpoint": "35.238.1.191",
+        "initialClusterVersion": "1.14.10-gke.17",
+        "instanceGroupUrls": [
+          "https://www.googleapis.com/compute/v1/projects/testproject/zones/us-central1-c/instanceGroupManagers/gke-workloadidentity-ena-default-pool-a62cc6f6-grp"
+        ],
+        "ipAllocationPolicy": {
+          "clusterIpv4Cidr": "10.32.0.0/14",
+          "clusterIpv4CidrBlock": "10.32.0.0/14",
+          "clusterSecondaryRangeName": "gke-workloadidentity-enabled-pods-19f71452",
+          "servicesIpv4Cidr": "10.0.0.0/20",
+          "servicesIpv4CidrBlock": "10.0.0.0/20",
+          "servicesSecondaryRangeName": "gke-workloadidentity-enabled-services-19f71452",
+          "useIpAliases": true
+        },
+        "labelFingerprint": "a9dc16a7",
+        "legacyAbac": {},
+        "location": "us-central1-c",
+        "locations": [
+          "us-central1-c"
+        ],
+        "loggingService": "logging.googleapis.com/kubernetes",
+        "maintenancePolicy": {
+          "resourceVersion": "e3b0c442"
+        },
+        "masterAuthorizedNetworksConfig": {},
+        "monitoringService": "monitoring.googleapis.com/kubernetes",
+        "name": "workloadidentity-enabled",
+        "network": "default",
+        "networkConfig": {
+          "network": "projects/testproject/global/networks/default",
+          "subnetwork": "projects/testproject/regions/us-central1/subnetworks/default"
+        },
+        "networkPolicy": {},
+        "nodePools": [
+          {
+            "autoscaling": {},
+            "config": {
+              "diskSizeGb": 100,
+              "diskType": "pd-standard",
+              "imageType": "COS",
+              "machineType": "n1-standard-1",
+              "metadata": {
+                "disable-legacy-endpoints": "true"
+              },
+              "oauthScopes": [
+                "https://www.googleapis.com/auth/devstorage.read_only",
+                "https://www.googleapis.com/auth/logging.write",
+                "https://www.googleapis.com/auth/monitoring",
+                "https://www.googleapis.com/auth/servicecontrol",
+                "https://www.googleapis.com/auth/service.management.readonly",
+                "https://www.googleapis.com/auth/trace.append"
+              ],
+              "serviceAccount": "default",
+              "shieldedInstanceConfig": {
+                "enableIntegrityMonitoring": true
+              },
+              "workloadMetadataConfig": {
+                "mode": "GKE_METADATA"
+              }
+            },
+            "initialNodeCount": 3,
+            "instanceGroupUrls": [
+              "https://www.googleapis.com/compute/v1/projects/testproject/zones/us-central1-c/instanceGroupManagers/gke-workloadidentity-ena-default-pool-a62cc6f6-grp"
+            ],
+            "locations": [
+              "us-central1-c"
+            ],
+            "management": {
+              "autoRepair": true,
+              "autoUpgrade": true
+            },
+            "maxPodsConstraint": {
+              "maxPodsPerNode": "110"
+            },
+            "name": "default-pool",
+            "podIpv4CidrSize": 24,
+            "selfLink": "https://container.googleapis.com/v1/projects/testproject/zones/us-central1-c/clusters/workloadidentity-enabled/nodePools/default-pool",
+            "status": "RUNNING",
+            "version": "1.14.10-gke.17"
+          }
+        ],
+        "selfLink": "https://container.googleapis.com/v1/projects/testproject/zones/us-central1-c/clusters/workloadidentity-enabled",
+        "servicesIpv4Cidr": "10.0.0.0/20",
+        "shieldedNodes": {},
+        "status": "RUNNING",
+        "subnetwork": "default",
+        "workloadIdentityConfig": {
+          "workloadPool": "testproject.svc.id.goog"
+        },
+        "zone": "us-central1-c"
+      }
+    },
+    "ancestors": [
+      "projects/1111111111",
+      "folders/11111111",
+      "organizations/11111111"
+    ]
+  },
+  {
+    "name": "//container.googleapis.com/projects/testproject/zones/us-central1-c/clusters/workloadidentity-disabled",
+    "asset_type": "container.googleapis.com/Cluster",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://container.googleapis.com/$discovery/rest",
+      "discovery_name": "Cluster",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/1111111111",
+      "data": {
+        "addonsConfig": {
+          "horizontalPodAutoscaling": {},
+          "httpLoadBalancing": {},
+          "kubernetesDashboard": {
+            "disabled": true
+          },
+          "networkPolicyConfig": {
+            "disabled": true
+          }
+        },
+        "authenticatorGroupsConfig": {},
+        "clusterIpv4Cidr": "10.24.0.0/14",
+        "createTime": "2020-03-07T04:24:11+00:00",
+        "currentMasterVersion": "1.14.10-gke.17",
+        "currentNodeCount": 3,
+        "currentNodeVersion": "1.14.10-gke.17",
+        "databaseEncryption": {
+          "state": "DECRYPTED"
+        },
+        "defaultMaxPodsConstraint": {
+          "maxPodsPerNode": "110"
+        },
+        "endpoint": "34.70.118.78",
+        "initialClusterVersion": "1.14.10-gke.17",
+        "instanceGroupUrls": [
+          "https://www.googleapis.com/compute/v1/projects/testproject/zones/us-central1-c/instanceGroupManagers/gke-workloadidentity-dis-default-pool-cc31d8dd-grp"
+        ],
+        "ipAllocationPolicy": {
+          "clusterIpv4Cidr": "10.24.0.0/14",
+          "clusterIpv4CidrBlock": "10.24.0.0/14",
+          "clusterSecondaryRangeName": "gke-workloadidentity-disabled-pods-ad4bc069",
+          "servicesIpv4Cidr": "10.88.0.0/20",
+          "servicesIpv4CidrBlock": "10.88.0.0/20",
+          "servicesSecondaryRangeName": "gke-workloadidentity-disabled-services-ad4bc069",
+          "useIpAliases": true
+        },
+        "labelFingerprint": "a9dc16a7",
+        "legacyAbac": {},
+        "location": "us-central1-c",
+        "locations": [
+          "us-central1-c"
+        ],
+        "loggingService": "logging.googleapis.com/kubernetes",
+        "maintenancePolicy": {
+          "resourceVersion": "e3b0c442"
+        },
+        "masterAuthorizedNetworksConfig": {},
+        "monitoringService": "monitoring.googleapis.com/kubernetes",
+        "name": "workloadidentity-disabled",
+        "network": "default",
+        "networkConfig": {
+          "network": "projects/testproject/global/networks/default",
+          "subnetwork": "projects/testproject/regions/us-central1/subnetworks/default"
+        },
+        "networkPolicy": {},
+        "nodePools": [
+          {
+            "autoscaling": {},
+            "config": {
+              "diskSizeGb": 100,
+              "diskType": "pd-standard",
+              "imageType": "COS",
+              "machineType": "n1-standard-1",
+              "metadata": {
+                "disable-legacy-endpoints": "true"
+              },
+              "oauthScopes": [
+                "https://www.googleapis.com/auth/devstorage.read_only",
+                "https://www.googleapis.com/auth/logging.write",
+                "https://www.googleapis.com/auth/monitoring",
+                "https://www.googleapis.com/auth/servicecontrol",
+                "https://www.googleapis.com/auth/service.management.readonly",
+                "https://www.googleapis.com/auth/trace.append"
+              ],
+              "serviceAccount": "default",
+              "shieldedInstanceConfig": {
+                "enableIntegrityMonitoring": true
+              }
+            },
+            "initialNodeCount": 3,
+            "instanceGroupUrls": [
+              "https://www.googleapis.com/compute/v1/projects/testproject/zones/us-central1-c/instanceGroupManagers/gke-workloadidentity-dis-default-pool-cc31d8dd-grp"
+            ],
+            "locations": [
+              "us-central1-c"
+            ],
+            "management": {
+              "autoRepair": true,
+              "autoUpgrade": true
+            },
+            "maxPodsConstraint": {
+              "maxPodsPerNode": "110"
+            },
+            "name": "default-pool",
+            "podIpv4CidrSize": 24,
+            "selfLink": "https://container.googleapis.com/v1/projects/testproject/zones/us-central1-c/clusters/workloadidentity-disabled/nodePools/default-pool",
+            "status": "RUNNING",
+            "version": "1.14.10-gke.17"
+          }
+        ],
+        "selfLink": "https://container.googleapis.com/v1/projects/testproject/zones/us-central1-c/clusters/workloadidentity-disabled",
+        "servicesIpv4Cidr": "10.88.0.0/20",
+        "shieldedNodes": {},
+        "status": "RUNNING",
+        "subnetwork": "default",
+        "zone": "us-central1-c"
+      }
+    },
+    "ancestors": [
+      "projects/1111111111",
+      "folders/11111111",
+      "organizations/11111111"
+    ]
+  },
+  {
+    "name": "//container.googleapis.com/projects/testproject/zones/us-central1-c/clusters/workloadidentity-enabled-beta",
+    "asset_type": "container.googleapis.com/Cluster",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://container.googleapis.com/$discovery/rest",
+      "discovery_name": "Cluster",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/1111111111",
+      "data": {
+        "addonsConfig": {
+          "horizontalPodAutoscaling": {},
+          "httpLoadBalancing": {},
+          "kubernetesDashboard": {
+            "disabled": true
+          },
+          "networkPolicyConfig": {
+            "disabled": true
+          }
+        },
+        "authenticatorGroupsConfig": {},
+        "clusterIpv4Cidr": "10.32.0.0/14",
+        "createTime": "2020-03-07T04:23:46+00:00",
+        "currentMasterVersion": "1.14.10-gke.17",
+        "currentNodeCount": 3,
+        "currentNodeVersion": "1.14.10-gke.17",
+        "databaseEncryption": {
+          "state": "DECRYPTED"
+        },
+        "defaultMaxPodsConstraint": {
+          "maxPodsPerNode": "110"
+        },
+        "endpoint": "35.238.1.191",
+        "initialClusterVersion": "1.14.10-gke.17",
+        "instanceGroupUrls": [
+          "https://www.googleapis.com/compute/v1/projects/testproject/zones/us-central1-c/instanceGroupManagers/gke-workloadidentity-ena-default-pool-a62cc6f6-grp"
+        ],
+        "ipAllocationPolicy": {
+          "clusterIpv4Cidr": "10.32.0.0/14",
+          "clusterIpv4CidrBlock": "10.32.0.0/14",
+          "clusterSecondaryRangeName": "gke-workloadidentity-enabled-pods-19f71452",
+          "servicesIpv4Cidr": "10.0.0.0/20",
+          "servicesIpv4CidrBlock": "10.0.0.0/20",
+          "servicesSecondaryRangeName": "gke-workloadidentity-enabled-services-19f71452",
+          "useIpAliases": true
+        },
+        "labelFingerprint": "a9dc16a7",
+        "legacyAbac": {},
+        "location": "us-central1-c",
+        "locations": [
+          "us-central1-c"
+        ],
+        "loggingService": "logging.googleapis.com/kubernetes",
+        "maintenancePolicy": {
+          "resourceVersion": "e3b0c442"
+        },
+        "masterAuthorizedNetworksConfig": {},
+        "monitoringService": "monitoring.googleapis.com/kubernetes",
+        "name": "workloadidentity-enabled",
+        "network": "default",
+        "networkConfig": {
+          "network": "projects/testproject/global/networks/default",
+          "subnetwork": "projects/testproject/regions/us-central1/subnetworks/default"
+        },
+        "networkPolicy": {},
+        "nodePools": [
+          {
+            "autoscaling": {},
+            "config": {
+              "diskSizeGb": 100,
+              "diskType": "pd-standard",
+              "imageType": "COS",
+              "machineType": "n1-standard-1",
+              "metadata": {
+                "disable-legacy-endpoints": "true"
+              },
+              "oauthScopes": [
+                "https://www.googleapis.com/auth/devstorage.read_only",
+                "https://www.googleapis.com/auth/logging.write",
+                "https://www.googleapis.com/auth/monitoring",
+                "https://www.googleapis.com/auth/servicecontrol",
+                "https://www.googleapis.com/auth/service.management.readonly",
+                "https://www.googleapis.com/auth/trace.append"
+              ],
+              "serviceAccount": "default",
+              "shieldedInstanceConfig": {
+                "enableIntegrityMonitoring": true
+              },
+              "workloadMetadataConfig": {
+                "mode": "GKE_METADATA"
+              }
+            },
+            "initialNodeCount": 3,
+            "instanceGroupUrls": [
+              "https://www.googleapis.com/compute/v1/projects/testproject/zones/us-central1-c/instanceGroupManagers/gke-workloadidentity-ena-default-pool-a62cc6f6-grp"
+            ],
+            "locations": [
+              "us-central1-c"
+            ],
+            "management": {
+              "autoRepair": true,
+              "autoUpgrade": true
+            },
+            "maxPodsConstraint": {
+              "maxPodsPerNode": "110"
+            },
+            "name": "default-pool",
+            "podIpv4CidrSize": 24,
+            "selfLink": "https://container.googleapis.com/v1/projects/testproject/zones/us-central1-c/clusters/workloadidentity-enabled-beta/nodePools/default-pool",
+            "status": "RUNNING",
+            "version": "1.14.10-gke.17"
+          }
+        ],
+        "selfLink": "https://container.googleapis.com/v1/projects/testproject/zones/us-central1-c/clusters/workloadidentity-enabled-beta",
+        "servicesIpv4Cidr": "10.0.0.0/20",
+        "shieldedNodes": {},
+        "status": "RUNNING",
+        "subnetwork": "default",
+        "workloadIdentityConfig": {
+          "identityNamespace": "testproject.svc.id.goog"
+        },
+        "zone": "us-central1-c"
+      }
+    },
+    "ancestors": [
+      "projects/1111111111",
+      "folders/11111111",
+      "organizations/11111111"
+    ]
+  }
+]

--- a/validator/test/fixtures/gke_enable_workload_identity/constraints/enable_gke_workload_identity/data.yaml
+++ b/validator/test/fixtures/gke_enable_workload_identity/constraints/enable_gke_workload_identity/data.yaml
@@ -1,0 +1,26 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPGKEEnableWorkloadIdentityConstraintV1
+metadata:
+  name: enable_gke_workload_identity
+  annotations:
+    description: Ensure Workload Identity is enabled on a GKE cluster
+spec:
+  severity: high
+  match:
+    gcp:
+      target: ["organization/*"]
+  parameters: {}


### PR DESCRIPTION
The constraint checks that workload identity is enabled on the cluster. I include both the v1 version of the configuration, which appears in CAI, and the beta version, which appears in Terraform validator when the beta provider is used.