### PR TITLE
Fixed bug introduced in PR #261

### DIFF
--- a/validator/bigquery_dataset_world_readable.rego
+++ b/validator/bigquery_dataset_world_readable.rego
@@ -29,6 +29,8 @@ deny[{
 		asset.iam_policy.bindings[_].members[_] == "allAuthenticatedUsers",
 	]
 
+	world_readable_checks[_] == true
+
 	message := sprintf("%v is publicly accessable", [asset.name])
 	metadata := {"resource": asset.name}
 }

--- a/validator/bigquery_dataset_world_readable_test.rego
+++ b/validator/bigquery_dataset_world_readable_test.rego
@@ -25,8 +25,6 @@ test_bigquery_iam_violations {
 		"//bigquery.googleapis.com/projects/test-project/datasets/world-readable-allUsers",
 		"//bigquery.googleapis.com/projects/test-project/datasets/world-readable-allAuthenticatedUsers",
 		"//bigquery.googleapis.com/projects/test-project/datasets/world-readable-both",
-		# TODO: fix the (existing) bug in this constraint:
-		"//bigquery.googleapis.com/projects/test-project/datasets/not-world-readable",
 	}
 
 	test_utils.check_test_violations(data.test.fixtures.bigquery_dataset_world_readable.assets, [data.test.fixtures.bigquery_dataset_world_readable.constraints], template_name, expected_resource_names)


### PR DESCRIPTION
My changes to GCPBigQueryDatasetWorldReadableConstraintV1 introduced a bug considering every dataset as violation. Should be fixed now.