### PR TITLE
Added policy for Compute Engine disk resource policies.

### DIFF
--- a/policies/templates/gcp_compute_disk_resource_policies_v1.yaml
+++ b/policies/templates/gcp_compute_disk_resource_policies_v1.yaml
@@ -1,0 +1,115 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This template is for policies auditing Persistent Disk resource
+# policies (eg. snapshot schedules). It supports allowlist or denylist
+# modes, as well as exempting selected assets from the list.
+
+apiVersion: templates.gatekeeper.sh/v1alpha1
+kind: ConstraintTemplate
+metadata:
+  name: gcp-compute-disk-resource-policies-v1
+spec:
+  crd:
+    spec:
+      names:
+        kind: GCPComputeDiskResourcePoliciesConstraintV1
+      validation:
+        openAPIV3Schema:
+          properties:
+            mode:
+              type: string
+              enum: [denylist, allowlist]
+              description: "String identifying the operational mode, allowlist or denylist. In allowlist mode, 
+              disk resource policies are only allowed in the policies specified in the 'resource_policies' parameter. 
+              In denylist mode, all disk resources policies are allowed except those listed in the 'resource_policies' 
+              parameter."
+            exemptions:
+              type: array
+              items: string
+              description: "Array of disk assets to exempt from resource policies restriction. String values in the array 
+              should correspond to the full name values of exempted policies."
+            resourcePolicies:
+              type: array
+              items: string
+              description: "Array of resource policies to be allowed or denied. Should be the full URL syntax,
+              e.g. https://www.googleapis.com/compute/v1/projects/my-project/regions/europe-north1/resourcePolicies/snapshot-schedule."
+  targets:
+    validation.gcp.forsetisecurity.org:
+      rego: | #INLINE("validator/compute_disk_resource_policies.rego")
+           #
+           # Copyright 2020 Google LLC
+           #
+           # Licensed under the Apache License, Version 2.0 (the "License");
+           # you may not use this file except in compliance with the License.
+           # You may obtain a copy of the License at
+           #
+           #      http://www.apache.org/licenses/LICENSE-2.0
+           #
+           # Unless required by applicable law or agreed to in writing, software
+           # distributed under the License is distributed on an "AS IS" BASIS,
+           # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+           # See the License for the specific language governing permissions and
+           # limitations under the License.
+           #
+           
+           package templates.gcp.GCPComputeDiskResourcePoliciesConstraintV1
+           
+           import data.validator.gcp.lib as lib
+           
+           #####################################
+           # Find Compute Persistent Disk Resource Policy Violations
+           #####################################
+           deny[{
+           	"msg": message,
+           	"details": metadata,
+           }] {
+           	constraint := input.constraint
+           	lib.get_constraint_params(constraint, params)
+           
+           	# Verify that resource is Disk or RegionDisk
+           	asset := input.asset
+           	{asset.asset_type} == {asset.asset_type} & {"compute.googleapis.com/Disk", "compute.googleapis.com/RegionDisk"}
+           
+           	# Check if resource is in exempt list
+           	exempt_list := params.exemptions
+           	matches := {asset.name} & cast_set(exempt_list)
+           	count(matches) == 0
+           
+           	# Check that resource policy is in allowlist/denylist
+           	asset_resource_policies := lib.get_default(asset.resource.data, "resourcePolicies", [""])
+           	target_resource_policies := params.resourcePolicies
+           	resource_policies_matches := cast_set(asset_resource_policies) & cast_set(target_resource_policies)
+           	target_resource_policies_match_count(params.mode, desired_count)
+           	count(resource_policies_matches) == desired_count
+           
+           	message := sprintf("%v has an empty or disallowed resource policy.", [asset.name])
+           	metadata := {"resource": asset.name, "resource_policies": asset_resource_policies}
+           }
+           
+           #################
+           # Rule Utilities
+           #################
+           
+           # Determine the overlap between resource policies under test and constraint
+           # By default (allowlist), we violate if there isn't overlap
+           target_resource_policies_match_count(mode) = 0 {
+           	mode != "denylist"
+           }
+           
+           target_resource_policies_match_count(mode) = 1 {
+           	mode == "denylist"
+           }
+           #ENDINLINE

--- a/samples/compute_disk_resource_policies.yaml
+++ b/samples/compute_disk_resource_policies.yaml
@@ -1,0 +1,25 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPComputeDiskResourcePoliciesConstraintV1
+metadata:
+  name: compute_disk_resource_policies_allowlist_one
+spec:
+  severity: high
+  parameters:
+    mode: "allowlist"
+    resourcePolicies:
+      - https://www.googleapis.com/compute/v1/projects/my-test-project/regions/europe-north1/resourcePolicies/test-schedule
+    exemptions: []

--- a/validator/compute_disk_resource_policies.rego
+++ b/validator/compute_disk_resource_policies.rego
@@ -1,0 +1,63 @@
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package templates.gcp.GCPComputeDiskResourcePoliciesConstraintV1
+
+import data.validator.gcp.lib as lib
+
+#####################################
+# Find Compute Persistent Disk Resource Policy Violations
+#####################################
+deny[{
+	"msg": message,
+	"details": metadata,
+}] {
+	constraint := input.constraint
+	lib.get_constraint_params(constraint, params)
+
+	# Verify that resource is Disk or RegionDisk
+	asset := input.asset
+	{asset.asset_type} == {asset.asset_type} & {"compute.googleapis.com/Disk", "compute.googleapis.com/RegionDisk"}
+
+	# Check if resource is in exempt list
+	exempt_list := params.exemptions
+	matches := {asset.name} & cast_set(exempt_list)
+	count(matches) == 0
+
+	# Check that resource policy is in allowlist/denylist
+	asset_resource_policies := lib.get_default(asset.resource.data, "resourcePolicies", [""])
+	target_resource_policies := params.resourcePolicies
+	resource_policies_matches := cast_set(asset_resource_policies) & cast_set(target_resource_policies)
+	target_resource_policies_match_count(params.mode, desired_count)
+	count(resource_policies_matches) == desired_count
+
+	message := sprintf("%v has an empty or disallowed resource policy.", [asset.name])
+	metadata := {"resource": asset.name, "resource_policies": asset_resource_policies}
+}
+
+#################
+# Rule Utilities
+#################
+
+# Determine the overlap between resource policies under test and constraint
+# By default (allowlist), we violate if there isn't overlap
+target_resource_policies_match_count(mode) = 0 {
+	mode != "denylist"
+}
+
+target_resource_policies_match_count(mode) = 1 {
+	mode == "denylist"
+}

--- a/validator/compute_disk_resource_policies_test.rego
+++ b/validator/compute_disk_resource_policies_test.rego
@@ -1,0 +1,86 @@
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package templates.gcp.GCPComputeDiskResourcePoliciesConstraintV1
+
+template_name := "GCPComputeDiskResourcePoliciesConstraintV1"
+
+import data.validator.test_utils as test_utils
+
+import data.test.fixtures.compute_disk_resource_policies.assets.disks as fixture_disks
+import data.test.fixtures.compute_disk_resource_policies.assets.instances as fixture_instances
+import data.test.fixtures.compute_disk_resource_policies.constraints as fixture_constraints
+
+# Test logic for allowlisting/denylisting
+test_target_resource_policies_match_count_allowlist {
+	target_resource_policies_match_count("allowlist", match_count)
+	match_count == 0
+}
+
+test_target_resource_policies_match_count_denylist {
+	target_resource_policies_match_count("denylist", match_count)
+	match_count == 1
+}
+
+test_compute_disk_resource_policies_no_assets {
+	test_utils.check_test_violations_count([], [], template_name, 0)
+}
+
+test_compute_disk_resource_policies_no_constraints {
+	test_utils.check_test_violations_count(fixture_disks, [], template_name, 0)
+}
+
+test_compute_disk_resource_policies_invalid_asset {
+	test_utils.check_test_violations_count(fixture_instances, [], template_name, 0)
+}
+
+test_compute_disk_resource_policies_default {
+	test_utils.check_test_violations_count(fixture_disks, [fixture_constraints.resource_policies_default], template_name, 0)
+}
+
+test_compute_disk_resource_policies_denylist_none {
+	test_utils.check_test_violations_count(fixture_disks, [fixture_constraints.denylist_none], template_name, 0)
+}
+
+test_compute_disk_resource_policies_allowlist_none {
+	test_utils.check_test_violations_count(fixture_disks, [fixture_constraints.allowlist_none], template_name, count(fixture_disks))
+}
+
+test_compute_disk_resource_policies_denylist_one {
+	resource_names := {"//compute.googleapis.com/projects/my-test-project/zones/europe-north1-c/disks/incorrect-resource-policies"}
+	test_utils.check_test_violations(fixture_disks, [fixture_constraints.denylist_one], template_name, resource_names)
+}
+
+test_compute_disk_resource_policies_denylist_one_exemption {
+	test_utils.check_test_violations_count(fixture_disks, [fixture_constraints.denylist_one_exemption], template_name, 0)
+}
+
+test_compute_disk_resource_policies_allowlist_one {
+	test_utils.check_test_violations_count(fixture_disks, [fixture_constraints.allowlist_one], template_name, count(fixture_disks) - 1)
+}
+
+test_compute_disk_resource_policies_allowlist_one_exemption {
+	test_utils.check_test_violations_count(fixture_disks, [fixture_constraints.allowlist_one_exemption], template_name, count(fixture_disks) - 2)
+}
+
+test_compute_disk_resource_policies_denylist_all {
+	test_utils.check_test_violations_count(fixture_disks, [fixture_constraints.denylist_all], template_name, count(fixture_disks) - 1)
+}
+
+# Test allowlist with all resource_policies
+test_compute_disk_resource_policies_allowlist_all {
+	test_utils.check_test_violations_count(fixture_disks, [fixture_constraints.allowlist_all], template_name, 0)
+}

--- a/validator/test/fixtures/compute_disk_resource_policies/assets/disks/data.json
+++ b/validator/test/fixtures/compute_disk_resource_policies/assets/disks/data.json
@@ -1,0 +1,147 @@
+[
+    {
+        "asset_type": "compute.googleapis.com/Disk",
+        "name": "//compute.googleapis.com/projects/my-test-project/zones/europe-north1-c/disks/no-resource-policies",
+        "resource": {
+            "data": {
+                "creationTimestamp": "2020-03-03T03:29:52.602-08:00",
+                "guestOsFeature": [
+                    {
+                        "type": "VIRTIO_SCSI_MULTIQUEUE"
+                    }
+                ],
+                "guestOsFeatures": [
+                    {
+                        "type": "VIRTIO_SCSI_MULTIQUEUE"
+                    }
+                ],
+                "id": "6213023151944859968",
+                "labelFingerprint": "42WmSpB8rSM=",
+                "lastAttachTimestamp": "2020-03-03T03:29:52.603-08:00",
+                "license": [
+                    "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/licenses/debian-9-stretch"
+                ],
+                "licenseCode": [
+                    "1000205"
+                ],
+                "licenseCodes": [
+                    "1000205"
+                ],
+                "licenses": [
+                    "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/licenses/debian-9-stretch"
+                ],
+                "name": "no-resource-policies",
+                "physicalBlockSizeBytes": "4096",
+                "selfLink": "https://www.googleapis.com/compute/v1/projects/my-test-project/zones/europe-north1-c/disks/no-resource-policies",
+                "sizeGb": "10",
+                "sourceImage": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20200210",
+                "sourceImageId": "5678238726467047158",
+                "status": "READY",
+                "type": "https://www.googleapis.com/compute/v1/projects/my-test-project/zones/europe-north1-c/diskTypes/pd-standard",
+                "user": [
+                    "https://www.googleapis.com/compute/v1/projects/my-test-project/zones/europe-north1-c/instances/no-resource-policies"
+                ],
+                "users": [
+                    "https://www.googleapis.com/compute/v1/projects/my-test-project/zones/europe-north1-c/instances/no-resource-policies"
+                ],
+                "zone": "https://www.googleapis.com/compute/v1/projects/my-test-project/zones/europe-north1-c"
+            }
+        }
+    },
+    {
+        "asset_type": "compute.googleapis.com/RegionDisk",
+        "name": "//compute.googleapis.com/projects/my-test-project/regions/europe-north1/disks/has-correct-resource-policies",
+        "resource": {
+            "data": {
+                "creationTimestamp": "2019-11-20T02:01:51.039-08:00",
+                "description": "",
+                "id": "7162702857072325089",
+                "labelFingerprint": "42WmSpB8rSM=",
+                "lastAttachTimestamp": "2020-03-06T21:54:55.999-08:00",
+                "lastDetachTimestamp": "2020-03-06T21:54:51.651-08:00",
+                "name": "has-correct-resource-policies",
+                "physicalBlockSizeBytes": "4096",
+                "region": "https://www.googleapis.com/compute/v1/projects/my-test-project/regions/europe-north1",
+                "replicaZone": [
+                    "https://www.googleapis.com/compute/v1/projects/my-test-project/zones/europe-north1-c",
+                    "https://www.googleapis.com/compute/v1/projects/my-test-project/zones/europe-north1-a"
+                ],
+                "replicaZones": [
+                    "https://www.googleapis.com/compute/v1/projects/my-test-project/zones/europe-north1-c",
+                    "https://www.googleapis.com/compute/v1/projects/my-test-project/zones/europe-north1-a"
+                ],
+                "resourcePolicies": [
+                    "https://www.googleapis.com/compute/v1/projects/my-test-project/regions/europe-north1/resourcePolicies/test-schedule"
+                ],
+                "resourcePolicy": [
+                    "https://www.googleapis.com/compute/v1/projects/my-test-project/regions/europe-north1/resourcePolicies/test-schedule"
+                ],
+                "selfLink": "https://www.googleapis.com/compute/v1/projects/my-test-project/regions/europe-north1/disks/has-correct-resource-policies",
+                "sizeGb": "200",
+                "status": "READY",
+                "type": "https://www.googleapis.com/compute/v1/projects/my-test-project/regions/europe-north1/diskTypes/pd-ssd",
+                "user": [
+                    "https://www.googleapis.com/compute/v1/projects/my-test-project/zones/europe-north1-c/instances/has-correct-resource-policies"
+                ],
+                "users": [
+                    "https://www.googleapis.com/compute/v1/projects/my-test-project/zones/europe-north1-c/instances/has-correct-resource-policies"
+                ]
+            }
+        }
+    },
+    {
+        "asset_type": "compute.googleapis.com/Disk",
+        "name": "//compute.googleapis.com/projects/my-test-project/zones/europe-north1-c/disks/incorrect-resource-policies",
+        "resource": {
+            "data": {
+                "creationTimestamp": "2020-03-03T03:29:52.602-08:00",
+                "guestOsFeature": [
+                    {
+                        "type": "VIRTIO_SCSI_MULTIQUEUE"
+                    }
+                ],
+                "guestOsFeatures": [
+                    {
+                        "type": "VIRTIO_SCSI_MULTIQUEUE"
+                    }
+                ],
+                "id": "6213023151944859968",
+                "labelFingerprint": "42WmSpB8rSM=",
+                "lastAttachTimestamp": "2020-03-03T03:29:52.603-08:00",
+                "license": [
+                    "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/licenses/debian-9-stretch"
+                ],
+                "licenseCode": [
+                    "1000205"
+                ],
+                "licenseCodes": [
+                    "1000205"
+                ],
+                "licenses": [
+                    "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/licenses/debian-9-stretch"
+                ],
+                "name": "incorrect-resource-policies",
+                "physicalBlockSizeBytes": "4096",
+                "selfLink": "https://www.googleapis.com/compute/v1/projects/my-test-project/zones/europe-north1-c/disks/incorrect-resource-policies",
+                "sizeGb": "10",
+                "sourceImage": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20200210",
+                "sourceImageId": "5678238726467047158",
+                "status": "READY",
+                "type": "https://www.googleapis.com/compute/v1/projects/my-test-project/zones/europe-north1-c/diskTypes/pd-standard",
+                "user": [
+                    "https://www.googleapis.com/compute/v1/projects/my-test-project/zones/europe-north1-c/instances/incorrect-resource-policies"
+                ],
+                "users": [
+                    "https://www.googleapis.com/compute/v1/projects/my-test-project/zones/europe-north1-c/instances/incorrect-resource-policies"
+                ],
+                "resourcePolicies": [
+                    "https://www.googleapis.com/compute/v1/projects/my-test-project/regions/europe-north1/resourcePolicies/wrong-schedule"
+                ],
+                "resourcePolicy": [
+                    "https://www.googleapis.com/compute/v1/projects/my-test-project/regions/europe-north1/resourcePolicies/wrong-schedule"
+                ],
+                "zone": "https://www.googleapis.com/compute/v1/projects/my-test-project/zones/europe-north1-c"
+            }
+        }
+    }
+]

--- a/validator/test/fixtures/compute_disk_resource_policies/assets/instances/data.json
+++ b/validator/test/fixtures/compute_disk_resource_policies/assets/instances/data.json
@@ -1,0 +1,70 @@
+[
+    {
+        "name": "//compute.googleapis.com/projects/test-project/zones/us-east1-c/instances/vm-no-ip",
+        "asset_type": "compute.googleapis.com/Instance",
+        "resource": {
+          "version": "v1",
+          "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+          "discovery_name": "Instance",
+          "parent": "//cloudresourcemanager.googleapis.com/projects/68478495408",
+          "data": {
+            "cpuPlatform": "Intel Haswell",
+            "creationTimestamp": "2018-01-18T12:16:22.261-08:00",
+            "deletionProtection": false,
+            "disk": [
+              {
+                "autoDelete": true,
+                "boot": true,
+                "deviceName": "persistent-disk-0",
+                "guestOsFeature": [
+                  {
+                    "type": "VIRTIO_SCSI_MULTIQUEUE"
+                  }
+                ],
+                "index": 0,
+                "interface": "SCSI",
+                "license": [
+                  "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/licenses/debian-9-stretch"
+                ],
+                "mode": "READ_WRITE",
+                "source": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-east1-c/disks/vm-no-ip",
+                "type": "PERSISTENT"
+              }
+            ],
+            "id": "8987947392482197114",
+            "labelFingerprint": "42WmSpB8rSM=",
+            "machineType": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-east1-c/machineTypes/g1-small",
+            "name": "vm-no-ip",
+            "networkInterfaces": [
+              {
+                "fingerprint": "+QCnSman4bQ=",
+                "ipAddress": "10.1.0.2",
+                "name": "nic0",
+                "network": "https://www.googleapis.com/compute/v1/projects/test-project/global/networks/default",
+                "subnetwork": "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-east1/subnetworks/default-us-east1"
+              }
+            ],
+            "scheduling": {
+              "automaticRestart": true,
+              "onHostMaintenance": "MIGRATE",
+              "preemptible": false
+            },
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-east1-c/instances/vm-no-ip",
+            "serviceAccount": [
+              {
+                "email": "66666666666-compute@developer.gserviceaccount.com",
+                "scope": [
+                  "https://www.googleapis.com/auth/cloud-platform"
+                ]
+              }
+            ],
+            "startRestricted": false,
+            "status": "RUNNING",
+            "tags": {
+              "fingerprint": "42WmSpB8rSM="
+            },
+            "zone": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-east1-c"
+          }
+        }
+      }
+]

--- a/validator/test/fixtures/compute_disk_resource_policies/constraints/allowlist_all/data.yaml
+++ b/validator/test/fixtures/compute_disk_resource_policies/constraints/allowlist_all/data.yaml
@@ -1,0 +1,27 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPComputeDiskResourcePoliciesConstraintV1
+metadata:
+  name: compute_disk_resource_policies_allowlist_all
+spec:
+  severity: high
+  parameters:
+    mode: "allowlist"
+    resourcePolicies:
+    - https://www.googleapis.com/compute/v1/projects/my-test-project/regions/europe-north1/resourcePolicies/test-schedule
+    - https://www.googleapis.com/compute/v1/projects/my-test-project/regions/europe-north1/resourcePolicies/wrong-schedule
+    - ""
+    exemptions: []

--- a/validator/test/fixtures/compute_disk_resource_policies/constraints/allowlist_none/data.yaml
+++ b/validator/test/fixtures/compute_disk_resource_policies/constraints/allowlist_none/data.yaml
@@ -1,0 +1,24 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPComputeDiskResourcePoliciesConstraintV1
+metadata:
+  name: compute_disk_resource_policies_allowlist_none
+spec:
+  severity: high
+  parameters:
+    mode: "allowlist"
+    resourcePolicies: []
+    exemptions: []

--- a/validator/test/fixtures/compute_disk_resource_policies/constraints/allowlist_one/data.yaml
+++ b/validator/test/fixtures/compute_disk_resource_policies/constraints/allowlist_one/data.yaml
@@ -1,0 +1,25 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPComputeDiskResourcePoliciesConstraintV1
+metadata:
+  name: compute_disk_resource_policies_allowlist_one
+spec:
+  severity: high
+  parameters:
+    mode: "allowlist"
+    resourcePolicies:
+      - https://www.googleapis.com/compute/v1/projects/my-test-project/regions/europe-north1/resourcePolicies/test-schedule
+    exemptions: []

--- a/validator/test/fixtures/compute_disk_resource_policies/constraints/allowlist_one_exemption/data.yaml
+++ b/validator/test/fixtures/compute_disk_resource_policies/constraints/allowlist_one_exemption/data.yaml
@@ -1,0 +1,26 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPComputeDiskResourcePoliciesConstraintV1
+metadata:
+  name: compute_disk_resource_policies_allowlist_one_exemption
+spec:
+  severity: high
+  parameters:
+    mode: "allowlist"
+    resourcePolicies:
+      - https://www.googleapis.com/compute/v1/projects/my-test-project/regions/europe-north1/resourcePolicies/test-schedule
+    exemptions: 
+     - //compute.googleapis.com/projects/my-test-project/zones/europe-north1-c/disks/incorrect-resource-policies

--- a/validator/test/fixtures/compute_disk_resource_policies/constraints/denylist_all/data.yaml
+++ b/validator/test/fixtures/compute_disk_resource_policies/constraints/denylist_all/data.yaml
@@ -1,0 +1,26 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPComputeDiskResourcePoliciesConstraintV1
+metadata:
+  name: compute_disk_resource_policies_denylist_all
+spec:
+  severity: high
+  parameters:
+    mode: "denylist"
+    resourcePolicies:
+    - https://www.googleapis.com/compute/v1/projects/my-test-project/regions/europe-north1/resourcePolicies/test-schedule
+    - https://www.googleapis.com/compute/v1/projects/my-test-project/regions/europe-north1/resourcePolicies/wrong-schedule
+    exemptions: []

--- a/validator/test/fixtures/compute_disk_resource_policies/constraints/denylist_none/data.yaml
+++ b/validator/test/fixtures/compute_disk_resource_policies/constraints/denylist_none/data.yaml
@@ -1,0 +1,24 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPComputeDiskResourcePoliciesConstraintV1
+metadata:
+  name: compute_disk_resource_policies_denylist_none
+spec:
+  severity: high
+  parameters:
+    mode: "denylist"
+    resourcePolicies: []
+    exemptions: []

--- a/validator/test/fixtures/compute_disk_resource_policies/constraints/denylist_one/data.yaml
+++ b/validator/test/fixtures/compute_disk_resource_policies/constraints/denylist_one/data.yaml
@@ -1,0 +1,25 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPComputeDiskResourcePoliciesConstraintV1
+metadata:
+  name: ccompute_disk_resource_policies_denylist_one
+spec:
+  severity: high
+  parameters:
+    mode: "denylist"
+    resourcePolicies:
+      - https://www.googleapis.com/compute/v1/projects/my-test-project/regions/europe-north1/resourcePolicies/wrong-schedule
+    exemptions: []

--- a/validator/test/fixtures/compute_disk_resource_policies/constraints/resource_policies_default/data.yaml
+++ b/validator/test/fixtures/compute_disk_resource_policies/constraints/resource_policies_default/data.yaml
@@ -1,0 +1,20 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPComputeDiskResourcePoliciesConstraintV1
+metadata:
+  name: compute_disk_resource_policies_default
+spec:
+  severity: high


### PR DESCRIPTION
Adding a policy to check for disk `resourcePolicies` (eg. snapshot schedules). Supports both `Disk` and `RegionDisk`. Also supports an empty policy ("").