### PR TITLE
Remove plural field.

### DIFF
--- a/docs/constraint_template_authoring.md
+++ b/docs/constraint_template_authoring.md
@@ -27,9 +27,6 @@ The template name appears in three places in a template YAML file:
 *   CRD kind (under "spec" > "crd" > "spec" > "names" > "kind"): Camel case. It
     has the format of "GCP{resource}{feature}Constraint{version}" (example:
     "GCPStorageLoggingConstraintV1").
-*   CRD plural name (under "spec" > "crd" > "spec" > "names" > "plural"): Same
-    as CRD kind but in all lower case with the word "constraints" replacing
-    "constraint" (example: "gcpstorageloggingconstraintsv1")
 
 Wherever possible, follow [gcloud](https://cloud.google.com/sdk/gcloud/) group
 names for resource naming. For example, use "compute" instead of "gce", "sql"
@@ -296,7 +293,6 @@ spec:
     spec:
       names:
         kind: GCPExternalIpAccessConstraintV1
-        plural: gcpexternalipaccessconstraintsv1
       validation:
         openAPIV3Schema:
           properties:

--- a/policies/templates/gcp_iam_allowed_policy_member_domains.yaml
+++ b/policies/templates/gcp_iam_allowed_policy_member_domains.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       names:
         kind: GCPIAMAllowedPolicyMemberDomainsConstraintV1
-        plural: gcpiamallowedpolicymemberdomainsconstraintsv1
       validation:
         openAPIV3Schema:
           properties:


### PR DESCRIPTION
Plural isn't used, remove it from a template as well as the docs.