### PR TITLE
Bug fix in GKE Restrict Master Auth Constraint.

### DIFF
--- a/policies/templates/gcp_gke_restrict_client_auth_methods_v1.yaml
+++ b/policies/templates/gcp_gke_restrict_client_auth_methods_v1.yaml
@@ -59,8 +59,9 @@ spec:
             	asset.asset_type == "container.googleapis.com/Cluster"
             	cluster := asset.resource.data
             	master_auth := lib.get_default(cluster, "masterAuth", {})
+            	cluster_version := lib.get_default(cluster, "currentMasterVersion", "")
             
-            	not check_all_disabled(master_auth)
+            	not check_all_disabled(master_auth, cluster_version)
             
             	message := sprintf("%v has client certificate or static password authentication enabled.", [asset.name])
             	metadata := {"resource": asset.name}
@@ -69,11 +70,20 @@ spec:
             ###########################
             # Rule Utilities
             ###########################
-            check_all_disabled(master_auth) {
+            check_all_disabled(master_auth, cluster_version) {
             	# For clusters before v1.12, if masterAuth is unspecified, username will 
             	# be set to "admin", a random password will be generated, and a client certificate 
             	# will be issued.
+            	re_match("1\\.(1)?[012]\\.", cluster_version)
             	master_auth != {}
+            	auth_with_client_cert_disabled(master_auth) == true
+            	auth_with_static_password_disabled(master_auth) == true
+            }
+            
+            check_all_disabled(master_auth, cluster_version) {
+            	# For clusters after v1.12, if masterAuth is unspecified, then we have safe defaults:
+            	# no username auth, no client cert. 
+            	not re_match("1\\.(1)?[012]\\.", cluster_version)
             	auth_with_client_cert_disabled(master_auth) == true
             	auth_with_static_password_disabled(master_auth) == true
             }

--- a/validator/gke_restrict_client_auth_methods.rego
+++ b/validator/gke_restrict_client_auth_methods.rego
@@ -27,8 +27,9 @@ deny[{
 	asset.asset_type == "container.googleapis.com/Cluster"
 	cluster := asset.resource.data
 	master_auth := lib.get_default(cluster, "masterAuth", {})
+	cluster_version := lib.get_default(cluster, "currentMasterVersion", "")
 
-	not check_all_disabled(master_auth)
+	not check_all_disabled(master_auth, cluster_version)
 
 	message := sprintf("%v has client certificate or static password authentication enabled.", [asset.name])
 	metadata := {"resource": asset.name}
@@ -37,11 +38,20 @@ deny[{
 ###########################
 # Rule Utilities
 ###########################
-check_all_disabled(master_auth) {
+check_all_disabled(master_auth, cluster_version) {
 	# For clusters before v1.12, if masterAuth is unspecified, username will 
 	# be set to "admin", a random password will be generated, and a client certificate 
 	# will be issued.
+	re_match("1\\.(1)?[012]\\.", cluster_version)
 	master_auth != {}
+	auth_with_client_cert_disabled(master_auth) == true
+	auth_with_static_password_disabled(master_auth) == true
+}
+
+check_all_disabled(master_auth, cluster_version) {
+	# For clusters after v1.12, if masterAuth is unspecified, then we have safe defaults:
+	# no username auth, no client cert. 
+	not re_match("1\\.(1)?[012]\\.", cluster_version)
 	auth_with_client_cert_disabled(master_auth) == true
 	auth_with_static_password_disabled(master_auth) == true
 }

--- a/validator/gke_restrict_client_auth_methods_test.rego
+++ b/validator/gke_restrict_client_auth_methods_test.rego
@@ -16,47 +16,18 @@
 
 package templates.gcp.GCPGKERestrictClientAuthenticationMethodsConstraintV1
 
-import data.validator.gcp.lib as lib
+import data.test.fixtures.gke_restrict_client_auth_methods.assets as fixture_assets
+import data.test.fixtures.gke_restrict_client_auth_methods.constraints as fixture_constraints
+import data.validator.test_utils as test_utils
 
-all_violations[violation] {
-	resource := data.test.fixtures.gke_restrict_client_auth_methods.assets[_]
-	constraint := data.test.fixtures.gke_restrict_client_auth_methods.constraints.restrict_gke_client_auth_methods
+template_name := "GCPGKERestrictClientAuthenticationMethodsConstraintV1"
 
-	issues := deny with input.asset as resource
-		 with input.constraint as constraint
+test_gke_restrict_client_auth_methods {
+	expected_resource_names = {
+		"//container.googleapis.com/projects/transfer-repos/zones/us-central1-c/clusters/joe-clust",
+		"//container.googleapis.com/projects/transfer-repos/zones/us-central1-c/clusters/joe-clust2",
+		"//container.googleapis.com/projects/transfer-repos/zones/us-central1-c/clusters/joe-clust5",
+	}
 
-	violation := issues[_]
-}
-
-test_master_auth_not_specified {
-	violation := all_violations[_]
-	violation.details.resource == "//container.googleapis.com/projects/transfer-repos/zones/us-central1-c/clusters/joe-clust"
-}
-
-test_issue_client_cert_set_to_true {
-	violation := all_violations[_]
-	violation.details.resource == "//container.googleapis.com/projects/transfer-repos/zones/us-central1-c/clusters/joe-clust2"
-}
-
-test_issue_client_cert_set_to_false {
-	violation := all_violations[_]
-	resource_names := {x | x = violation.details.resource; violation.details.resource == "//container.googleapis.com/projects/transfer-repos/zones/us-central1-c/clusters/joe-clust3"}
-	count(resource_names) == 0
-}
-
-test_username_empty {
-	violation := all_violations[_]
-	resource_names := {x | x = violation.details.resource; violation.details.resource == "//container.googleapis.com/projects/transfer-repos/zones/us-central1-c/clusters/joe-clust4"}
-	count(resource_names) == 0
-}
-
-test_username_non_empty {
-	violation := all_violations[_]
-	violation.details.resource == "//container.googleapis.com/projects/transfer-repos/zones/us-central1-c/clusters/joe-clust5"
-}
-
-test_username_empty_and_issue_client_cert_set_to_false {
-	violation := all_violations[_]
-	resource_names := {x | x = violation.details.resource; violation.details.resource == "//container.googleapis.com/projects/transfer-repos/zones/us-central1-c/clusters/joe-clust6"}
-	count(resource_names) == 0
+	test_utils.check_test_violations(fixture_assets, [fixture_constraints.restrict_gke_client_auth_methods], template_name, expected_resource_names)
 }

--- a/validator/test/fixtures/gke_restrict_client_auth_methods/assets/data.json
+++ b/validator/test/fixtures/gke_restrict_client_auth_methods/assets/data.json
@@ -503,5 +503,123 @@
         "zone": "us-west1-b"
       }
     }
+  },
+  {
+    "name": "//container.googleapis.com/projects/transfer-repo/zones/us-central1-c/clusters/default-master-auth",
+    "asset_type": "container.googleapis.com/Cluster",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://container.googleapis.com/$discovery/rest",
+      "discovery_name": "Cluster",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/321240941520",
+      "data": {
+        "addonsConfig": {
+          "horizontalPodAutoscaling": {},
+          "httpLoadBalancing": {},
+          "kubernetesDashboard": {
+            "disabled": true
+          },
+          "networkPolicyConfig": {
+            "disabled": true
+          }
+        },
+        "authenticatorGroupsConfig": {},
+        "clusterIpv4Cidr": "10.56.0.0/14",
+        "createTime": "2020-03-05T17:35:40+00:00",
+        "currentMasterVersion": "1.14.10-gke.17",
+        "currentNodeCount": 3,
+        "currentNodeVersion": "1.14.10-gke.17",
+        "databaseEncryption": {
+          "state": "DECRYPTED"
+        },
+        "defaultMaxPodsConstraint": {
+          "maxPodsPerNode": "110"
+        },
+        "endpoint": "35.188.34.99",
+        "initialClusterVersion": "1.14.10-gke.17",
+        "instanceGroupUrls": [
+          "https://www.googleapis.com/compute/v1/projects/transfer-repo/zones/us-central1-c/instanceGroupManagers/gke-shielded-nodes-enabl-default-pool-86295a0a-grp"
+        ],
+        "ipAllocationPolicy": {
+          "clusterIpv4Cidr": "10.56.0.0/14",
+          "clusterIpv4CidrBlock": "10.56.0.0/14",
+          "clusterSecondaryRangeName": "gke-shielded-nodes-enabled-pods-fd0a23a7",
+          "servicesIpv4Cidr": "10.0.0.0/20",
+          "servicesIpv4CidrBlock": "10.0.0.0/20",
+          "servicesSecondaryRangeName": "gke-shielded-nodes-enabled-services-fd0a23a7",
+          "useIpAliases": true
+        },
+        "labelFingerprint": "a9dc16a7",
+        "legacyAbac": {},
+        "location": "us-central1-c",
+        "locations": [
+          "us-central1-c"
+        ],
+        "loggingService": "logging.googleapis.com/kubernetes",
+        "maintenancePolicy": {
+          "resourceVersion": "e3b0c442"
+        },
+        "masterAuthorizedNetworksConfig": {},
+        "monitoringService": "monitoring.googleapis.com/kubernetes",
+        "name": "shielded-nodes-enabled",
+        "network": "default",
+        "networkConfig": {
+          "network": "projects/transfer-repo/global/networks/default",
+          "subnetwork": "projects/transfer-repo/regions/us-central1/subnetworks/default"
+        },
+        "networkPolicy": {},
+        "nodePools": [
+          {
+            "autoscaling": {},
+            "config": {
+              "diskSizeGb": 100,
+              "diskType": "pd-standard",
+              "imageType": "COS",
+              "machineType": "n1-standard-1",
+              "metadata": {
+                "disable-legacy-endpoints": "true"
+              },
+              "oauthScopes": [
+                "https://www.googleapis.com/auth/devstorage.read_only",
+                "https://www.googleapis.com/auth/logging.write",
+                "https://www.googleapis.com/auth/monitoring",
+                "https://www.googleapis.com/auth/servicecontrol",
+                "https://www.googleapis.com/auth/service.management.readonly",
+                "https://www.googleapis.com/auth/trace.append"
+              ],
+              "serviceAccount": "default",
+              "shieldedInstanceConfig": {
+                "enableIntegrityMonitoring": true,
+                "enableSecureBoot": true
+              }
+            },
+            "initialNodeCount": 3,
+            "instanceGroupUrls": [
+              "https://www.googleapis.com/compute/v1/projects/transfer-repo/zones/us-central1-c/instanceGroupManagers/gke-shielded-nodes-enabl-default-pool-86295a0a-grp"
+            ],
+            "locations": [
+              "us-central1-c"
+            ],
+            "management": {
+              "autoRepair": true,
+              "autoUpgrade": true
+            },
+            "maxPodsConstraint": {
+              "maxPodsPerNode": "110"
+            },
+            "name": "default-pool",
+            "podIpv4CidrSize": 24,
+            "selfLink": "https://container.googleapis.com/v1/projects/transfer-repo/zones/us-central1-c/clusters/shielded-nodes-enabled/nodePools/default-pool",
+            "status": "RUNNING",
+            "version": "1.14.10-gke.17"
+          }
+        ],
+        "selfLink": "https://container.googleapis.com/v1/projects/transfer-repo/zones/us-central1-c/clusters/shielded-nodes-enabled",
+        "servicesIpv4Cidr": "10.0.0.0/20",
+        "status": "RUNNING",
+        "subnetwork": "default",
+        "zone": "us-central1-c"
+      }
+    }
   }
 ]


### PR DESCRIPTION
The CAI output from recent GKE clusters doesn't show the master_auth
block. I modified the constraint to only raise an error for master_auth
blocks for GKE versions < 1.12.