### PR TITLE
Fix template.

### DIFF
--- a/policies/templates/gcp_sql_instance_type_v1.yaml
+++ b/policies/templates/gcp_sql_instance_type_v1.yaml
@@ -32,7 +32,7 @@ spec:
               allow or deny. In the allow mode, only Cloud SQL instances
               with an instance type in the instance_types list will be allowed (the other ones will
               raise a violation). In the deny mode, the opposite is true. The default mode is deny."
-              default: "deny"
+#              default: "deny"
             sql_instance_types:
               type: array
               items: string


### PR DESCRIPTION
Setting the default value in the OpenAPI spec is not allowed by the Constraint
Framework as it has no actual effect on the rego that is executed and could be
a source of confusion if the two go out of sync.

Fixes: #306