### PR TITLE
Add IAM sample for restricting access to BQ datasets

### DIFF
--- a/samples/iam_restrict_gmail_bigquery_dataset.yaml
+++ b/samples/iam_restrict_gmail_bigquery_dataset.yaml
@@ -15,7 +15,7 @@
 apiVersion: constraints.gatekeeper.sh/v1alpha1
 kind: GCPIAMAllowedBindingsConstraintV1
 metadata:
-  name: blacklist_gmail_bigquery_dataset
+  name: blacklist-gmail-bigquery-dataset
   annotations:
     description: Enforce corporate domain by banning gmail.com addresses access to BigQuery datasets
     bundles.validator.forsetisecurity.org/forseti-security: v2.26.0

--- a/samples/iam_restrict_gmail_bigquery_dataset.yaml
+++ b/samples/iam_restrict_gmail_bigquery_dataset.yaml
@@ -1,0 +1,32 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPIAMAllowedBindingsConstraintV1
+metadata:
+  name: blacklist_gmail_bigquery_dataset
+  annotations:
+    description: Enforce corporate domain by banning gmail.com addresses access to BigQuery datasets
+    bundles.validator.forsetisecurity.org/forseti-security: v2.26.0
+spec:
+  severity: high
+  match:
+    target: ["organization/*"]
+    exclude: []
+  parameters:
+    mode: blacklist
+    assetType: bigquery.googleapis.com/Dataset
+    role: roles/*
+    members:
+    - "user:*@gmail.com"

--- a/samples/iam_restrict_googlegroups_bigquery_dataset.yaml
+++ b/samples/iam_restrict_googlegroups_bigquery_dataset.yaml
@@ -15,7 +15,7 @@
 apiVersion: constraints.gatekeeper.sh/v1alpha1
 kind: GCPIAMAllowedBindingsConstraintV1
 metadata:
-  name: blacklist_googlegroups_bigquery_dataset
+  name: blacklist-googlegroups-bigquery-dataset
   annotations:
     description: Enforce corporate domain by banning googlegroups.com addresses access to BigQuery datasets
     bundles.validator.forsetisecurity.org/forseti-security: v2.26.0

--- a/samples/iam_restrict_googlegroups_bigquery_dataset.yaml
+++ b/samples/iam_restrict_googlegroups_bigquery_dataset.yaml
@@ -1,0 +1,32 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPIAMAllowedBindingsConstraintV1
+metadata:
+  name: blacklist_googlegroups_bigquery_dataset
+  annotations:
+    description: Enforce corporate domain by banning googlegroups.com addresses access to BigQuery datasets
+    bundles.validator.forsetisecurity.org/forseti-security: v2.26.0
+spec:
+  severity: high
+  match:
+    target: ["organization/*"]
+    exclude: []
+  parameters:
+    mode: blacklist
+    assetType: bigquery.googleapis.com/Dataset
+    role: roles/*
+    members:
+    - "user:*@googlegroups.com"

--- a/validator/iam_allowed_bindings_test.rego
+++ b/validator/iam_allowed_bindings_test.rego
@@ -46,7 +46,7 @@ test_whitelist_role_domain_violation_count {
 test_whitelist_role_domain_violations {
 	violations := test_utils.get_test_violations(fixture_assets, [fixture_constraints.iam_allowed_bindings_whitelist_role_domain], template_name)
 	violation := violations[_]
-  violation.details.role == "roles/owner"
+	violation.details.role == "roles/owner"
 	violation.details.member == "user:evil@notgoogle.com"
 }
 

--- a/validator/iam_allowed_bindings_test.rego
+++ b/validator/iam_allowed_bindings_test.rego
@@ -44,9 +44,9 @@ test_whitelist_role_domain_violation_count {
 }
 
 test_whitelist_role_domain_violations {
-    violations := test_utils.get_test_violations(fixture_assets, [fixture_constraints.iam_allowed_bindings_whitelist_role_domain], template_name)
-    violation := violations[_]
-    violation.details.role == "roles/owner"
+	violations := test_utils.get_test_violations(fixture_assets, [fixture_constraints.iam_allowed_bindings_whitelist_role_domain], template_name)
+	violation := violations[_]
+  violation.details.role == "roles/owner"
 	violation.details.member == "user:evil@notgoogle.com"
 }
 
@@ -61,7 +61,7 @@ test_restrict_gmail_bigquery_dataset_violations_count {
 }
 
 test_restrict_gmail_bigquery_dataset_resources {
-	resource_names := {"//bigquery.googleapis.com/projects/12345/datasets/testdataset1", "//bigquery.googleapis.com/projects/12345/datasets/testdataset1"}
+	resource_names := {"//bigquery.googleapis.com/projects/12345/datasets/testdataset1"}
 	test_utils.check_test_violations_resources(fixture_assets, [fixture_constraints.iam_allowed_bindings_blacklist_gmail_bigquery_dataset], template_name, resource_names)
 }
 
@@ -71,6 +71,6 @@ test_restrict_googlegroups_bigquery_dataset_violations_count {
 }
 
 test_restrict_googlegroups_bigquery_dataset_resources {
-	resource_names := {"//bigquery.googleapis.com/projects/12345/datasets/testdataset2", "//bigquery.googleapis.com/projects/12345/datasets/testdataset2"}
+	resource_names := {"//bigquery.googleapis.com/projects/12345/datasets/testdataset2"}
 	test_utils.check_test_violations_resources(fixture_assets, [fixture_constraints.iam_allowed_bindings_blacklist_googlegroups_bigquery_dataset], template_name, resource_names)
 }

--- a/validator/iam_allowed_bindings_test.rego
+++ b/validator/iam_allowed_bindings_test.rego
@@ -16,82 +16,61 @@
 
 package templates.gcp.GCPIAMAllowedBindingsConstraintV1
 
+template_name := "GCPIAMAllowedBindingsConstraintV1"
+
+import data.validator.test_utils as test_utils
+
 import data.test.fixtures.iam_allowed_bindings.assets as fixture_assets
 import data.test.fixtures.iam_allowed_bindings.constraints as fixture_constraints
 
-# Find all violations on our test cases
-find_violations[violation] {
-	asset := fixture_assets[_]
-	constraint := data.test_constraints[_]
-
-	issues := deny with input.asset as asset
-		 with input.constraint as constraint
-
-	total_issues := count(issues)
-
-	violation := issues[_]
+# Test blacklist project
+test_blacklist_project_violation_count {
+	test_utils.check_test_violations_count(fixture_assets, [fixture_constraints.iam_allowed_bindings_blacklist_project], template_name, 1)
 }
 
-blacklist_role_violations[violation] {
-	constraints := [fixture_constraints.iam_allowed_bindings_blacklist_role]
-
-	found_violations := find_violations with data.test_constraints as constraints
-
-	violation := found_violations[_]
+# Test blacklist public
+test_blacklist_role_violation_count {
+	test_utils.check_test_violations_count(fixture_assets, [fixture_constraints.iam_allowed_bindings_blacklist_public], template_name, 2)
 }
 
-test_blacklist_role_violations {
-	count(blacklist_role_violations) = 2
+# Test blacklist role
+test_blacklist_project_violation_count {
+	test_utils.check_test_violations_count(fixture_assets, [fixture_constraints.iam_allowed_bindings_blacklist_role], template_name, 2)
 }
 
-blacklist_project_violations[violation] {
-	constraints := [fixture_constraints.iam_allowed_bindings_blacklist_project]
-
-	found_violations := find_violations with data.test_constraints as constraints
-
-	violation := found_violations[_]
-}
-
-test_blacklist_project_violations {
-	count(blacklist_project_violations) = 1
-}
-
-whitelist_role_domain_violations[violation] {
-	constraints := [fixture_constraints.iam_allowed_bindings_whitelist_role_domain]
-
-	found_violations := find_violations with data.test_constraints as constraints
-
-	violation := found_violations[_]
+# Test whitelist role domain
+test_whitelist_role_domain_violation_count {
+	test_utils.check_test_violations_count(fixture_assets, [fixture_constraints.iam_allowed_bindings_whitelist_role_domain], template_name, 1)
 }
 
 test_whitelist_role_domain_violations {
-	count(whitelist_role_domain_violations) = 1
-	violation := whitelist_role_domain_violations[_]
-	violation.details.role == "roles/owner"
+    violations := test_utils.get_test_violations(fixture_assets, [fixture_constraints.iam_allowed_bindings_whitelist_role_domain], template_name)
+    violation := violations[_]
+    violation.details.role == "roles/owner"
 	violation.details.member == "user:evil@notgoogle.com"
 }
 
-blacklist_public_violations[violation] {
-	constraints := [fixture_constraints.iam_allowed_bindings_blacklist_public]
-
-	found_violations := find_violations with data.test_constraints as constraints
-
-	violation := found_violations[_]
+# Test whitelist role members (no violations)
+test_whitelist_role_violation_count {
+	test_utils.check_test_violations_count(fixture_assets, [fixture_constraints.iam_allowed_bindings_whitelist_role_members], template_name, 0)
 }
 
-test_blacklist_public_violations {
-	count(blacklist_public_violations) = 2
+# Test blacklist to BigQuery dataset for gmail.com addresses
+test_restrict_gmail_bigquery_dataset_violations_count {
+	test_utils.check_test_violations_count(fixture_assets, [fixture_constraints.iam_allowed_bindings_blacklist_gmail_bigquery_dataset], template_name, 2)
 }
 
-# Try a constraint which shouldn't trigger any violations
-whitelist_role_no_violations[violation] {
-	constraints := [fixture_constraints.iam_allowed_bindings_whitelist_role_members]
-
-	found_violations := find_violations with data.test_constraints as constraints
-
-	violation := found_violations[_]
+test_restrict_gmail_bigquery_dataset_resources {
+	resource_names := {"//bigquery.googleapis.com/projects/12345/datasets/testdataset1", "//bigquery.googleapis.com/projects/12345/datasets/testdataset1"}
+	test_utils.check_test_violations_resources(fixture_assets, [fixture_constraints.iam_allowed_bindings_blacklist_gmail_bigquery_dataset], template_name, resource_names)
 }
 
-test_whitelist_role_no_violations {
-	count(whitelist_role_no_violations) = 0
+# Test blacklist to BigQuery dataset for googlegroups.com addresses
+test_restrict_googlegroups_bigquery_dataset_violations_count {
+	test_utils.check_test_violations_count(fixture_assets, [fixture_constraints.iam_allowed_bindings_blacklist_googlegroups_bigquery_dataset], template_name, 2)
+}
+
+test_restrict_googlegroups_bigquery_dataset_resources {
+	resource_names := {"//bigquery.googleapis.com/projects/12345/datasets/testdataset2", "//bigquery.googleapis.com/projects/12345/datasets/testdataset2"}
+	test_utils.check_test_violations_resources(fixture_assets, [fixture_constraints.iam_allowed_bindings_blacklist_googlegroups_bigquery_dataset], template_name, resource_names)
 }

--- a/validator/iam_allowed_bindings_test.rego
+++ b/validator/iam_allowed_bindings_test.rego
@@ -29,12 +29,12 @@ test_blacklist_project_violation_count {
 }
 
 # Test blacklist public
-test_blacklist_role_violation_count {
+test_blacklist_public_violation_count {
 	test_utils.check_test_violations_count(fixture_assets, [fixture_constraints.iam_allowed_bindings_blacklist_public], template_name, 2)
 }
 
 # Test blacklist role
-test_blacklist_project_violation_count {
+test_blacklist_role_violation_count {
 	test_utils.check_test_violations_count(fixture_assets, [fixture_constraints.iam_allowed_bindings_blacklist_role], template_name, 2)
 }
 

--- a/validator/test/fixtures/iam_allowed_bindings/assets/data.json
+++ b/validator/test/fixtures/iam_allowed_bindings/assets/data.json
@@ -54,5 +54,49 @@
                 }
             ]
         }
+    },
+    {
+        "name": "//bigquery.googleapis.com/projects/12345/datasets/testdataset1",
+        "asset_type": "bigquery.googleapis.com/Dataset",
+        "iam_policy": {
+            "version": 1,
+            "etag": "CdWC1qPLfdw=",
+            "bindings": [
+                {
+                    "role": "roles/bigquery.dataViewer",
+                    "members": [
+                        "user:user@gmail.com"
+                    ]
+                },
+                {
+                    "role": "roles/bigquery.dataOwner",
+                    "members": [
+                        "user:admin@gmail.com"
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "name": "//bigquery.googleapis.com/projects/12345/datasets/testdataset2",
+        "asset_type": "bigquery.googleapis.com/Dataset",
+        "iam_policy": {
+            "version": 1,
+            "etag": "CdWC1qPLfdw=",
+            "bindings": [
+                {
+                    "role": "roles/bigquery.dataViewer",
+                    "members": [
+                        "user:user@googlegroups.com"
+                    ]
+                },
+                {
+                    "role": "roles/bigquery.dataOwner",
+                    "members": [
+                        "user:admin@googlegroups.com"
+                    ]
+                }
+            ]
+        }
     }
 ]

--- a/validator/test/fixtures/iam_allowed_bindings/constraints/iam_allowed_bindings_blacklist_gmail_bigquery_dataset/data.yaml
+++ b/validator/test/fixtures/iam_allowed_bindings/constraints/iam_allowed_bindings_blacklist_gmail_bigquery_dataset/data.yaml
@@ -15,7 +15,7 @@
 apiVersion: constraints.gatekeeper.sh/v1alpha1
 kind: GCPIAMAllowedBindingsConstraintV1
 metadata:
-  name: blacklist_gmail_bigquery_dataset
+  name: blacklist-gmail-bigquery-dataset
   annotations:
     description: Enforce corporate domain by banning gmail.com addresses access to BigQuery datasets
     bundles.validator.forsetisecurity.org/forseti-security: v2.26.0

--- a/validator/test/fixtures/iam_allowed_bindings/constraints/iam_allowed_bindings_blacklist_gmail_bigquery_dataset/data.yaml
+++ b/validator/test/fixtures/iam_allowed_bindings/constraints/iam_allowed_bindings_blacklist_gmail_bigquery_dataset/data.yaml
@@ -1,0 +1,29 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPIAMAllowedBindingsConstraintV1
+metadata:
+  name: blacklist_gmail_bigquery_dataset
+  annotations:
+    description: Enforce corporate domain by banning gmail.com addresses access to BigQuery datasets
+    bundles.validator.forsetisecurity.org/forseti-security: v2.26.0
+spec:
+  severity: high
+  parameters:
+    mode: blacklist
+    assetType: bigquery.googleapis.com/Dataset
+    role: roles/*
+    members:
+      - "user:*@gmail.com"

--- a/validator/test/fixtures/iam_allowed_bindings/constraints/iam_allowed_bindings_blacklist_googlegroups_bigquery_dataset/data.yaml
+++ b/validator/test/fixtures/iam_allowed_bindings/constraints/iam_allowed_bindings_blacklist_googlegroups_bigquery_dataset/data.yaml
@@ -15,7 +15,7 @@
 apiVersion: constraints.gatekeeper.sh/v1alpha1
 kind: GCPIAMAllowedBindingsConstraintV1
 metadata:
-  name: blacklist_googlegroups_bigquery_dataset
+  name: blacklist-googlegroups-bigquery-dataset
   annotations:
     description: Enforce corporate domain by banning googlegroups.com addresses access to BigQuery datasets
     bundles.validator.forsetisecurity.org/forseti-security: v2.26.0

--- a/validator/test/fixtures/iam_allowed_bindings/constraints/iam_allowed_bindings_blacklist_googlegroups_bigquery_dataset/data.yaml
+++ b/validator/test/fixtures/iam_allowed_bindings/constraints/iam_allowed_bindings_blacklist_googlegroups_bigquery_dataset/data.yaml
@@ -1,0 +1,29 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPIAMAllowedBindingsConstraintV1
+metadata:
+  name: blacklist_googlegroups_bigquery_dataset
+  annotations:
+    description: Enforce corporate domain by banning googlegroups.com addresses access to BigQuery datasets
+    bundles.validator.forsetisecurity.org/forseti-security: v2.26.0
+spec:
+  severity: high
+  parameters:
+    mode: blacklist
+    assetType: bigquery.googleapis.com/Dataset
+    role: roles/*
+    members:
+      - "user:*@googlegroups.com"


### PR DESCRIPTION
Add samples restricting access to BQ datasets for gmail.com and googlegroups.com email addresses. Add unit tests for these samples, and update existing unit tests for this template to new format.

Resolves #314 