### PR TITLE
IAM Custom Role Permissions Constraint V1

### DIFF
--- a/policies/templates/gcp_iam_custom_role_permissions_v1.yaml
+++ b/policies/templates/gcp_iam_custom_role_permissions_v1.yaml
@@ -42,7 +42,8 @@ spec:
                 with bigquery, such as bigquery.savedqueries.get, bigquery.config.get
                 E.g. '*' will search for any permissions"
               type: array
-              items: string
+              items:
+                type: string
   targets:
    validation.gcp.forsetisecurity.org:
       rego: | #INLINE("validator/iam_custom_role_permissions.rego")

--- a/policies/templates/gcp_iam_custom_role_permissions_v1.yaml
+++ b/policies/templates/gcp_iam_custom_role_permissions_v1.yaml
@@ -31,7 +31,7 @@ spec:
               enum: [denylist, allowlist]
             title:
               description: "The custom role title to scan for, found on the IAM Roles page.
-              E.g. 'My Custom Role for BigQuery'"
+              E.g. 'My Custom Role for BigQuery'. Default will scan all role titles."
               type: string
             permissions:
               description: "Permissions to either allow or deny for the given custom role,
@@ -79,7 +79,10 @@ spec:
            
            	asset_permissions := asset.resource.data.includedPermissions[_]
            	asset_title := asset.resource.data.title
-           	lower(asset_title) == lower(params.title)
+           
+           	params_title := lib.get_default(params, "title", "*")
+           
+           	check_asset_title(asset_title, params_title)
            
            	mode := lib.get_default(params, "mode", "allowlist")
            
@@ -87,11 +90,11 @@ spec:
            	target_match_count(mode, desired_count)
            	count(matches_found) != desired_count
            
-           	message := sprintf("Custom role %v grants permission %v", [asset.name, asset_permissions])
+           	message := sprintf("Role %v grants permission %v", [asset.name, asset_permissions])
            
            	metadata := {
            		"resource": asset.name,
-           		"custom_role_title": asset_title,
+           		"role_title": asset_title,
            		"permission": asset_permissions,
            	}
            }
@@ -107,6 +110,15 @@ spec:
            
            target_match_count(mode) = 1 {
            	mode == "allowlist"
+           }
+           
+           check_asset_title(asset_title, params_title) {
+           	params_title == "*"
+           }
+           
+           check_asset_title(asset_title, params_title) {
+           	params_title != "*"
+           	lower(asset_title) == lower(params_title)
            }
            
            # If the member in constraint is written as a single "*", turn it into super

--- a/policies/templates/gcp_iam_custom_role_permissions_v1.yaml
+++ b/policies/templates/gcp_iam_custom_role_permissions_v1.yaml
@@ -1,0 +1,120 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: templates.gatekeeper.sh/v1alpha1
+kind: ConstraintTemplate
+metadata:
+  name: gcp-iam-custom-role-permissions-v1
+spec:
+  crd:
+    spec:
+      names:
+        kind: GCPIAMCustomRolePermissionsConstraintV1
+      validation:
+        openAPIV3Schema:
+          required: ["mode", "permissions"]
+          properties:
+            mode:
+              description: "Enforcement mode, defaults to allowlist"
+              type: string
+              enum: [denylist, allowlist]
+            title:
+              description: "The custom role title to scan for, found on the IAM Roles page.
+              E.g. 'My Custom Role for BigQuery'"
+              type: string
+            permissions:
+              description: "Permissions to either allow or deny for the given custom role,
+                depending on mode; Wildcards (*) supported.
+                E.g. 'bigquery.datasets.*' will search for any permissions that
+                start with bigquery.datasets, such as bigquery.datasets.get
+                E.g. 'bigquery.**' will search for any permissions that start
+                with bigquery, such as bigquery.savedqueries.get, bigquery.config.get
+                E.g. '*' will search for any permissions"
+              type: array
+              items: string
+  targets:
+   validation.gcp.forsetisecurity.org:
+      rego: | #INLINE("validator/iam_custom_role_permissions.rego")
+           #
+           # Copyright 2020 Google LLC
+           #
+           # Licensed under the Apache License, Version 2.0 (the "License");
+           # you may not use this file except in compliance with the License.
+           # You may obtain a copy of the License at
+           #
+           #      http://www.apache.org/licenses/LICENSE-2.0
+           #
+           # Unless required by applicable law or agreed to in writing, software
+           # distributed under the License is distributed on an "AS IS" BASIS,
+           # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+           # See the License for the specific language governing permissions and
+           # limitations under the License.
+           #
+           
+           package templates.gcp.GCPIAMCustomRolePermissionsConstraintV1
+           
+           import data.validator.gcp.lib as lib
+           
+           deny[{
+           	"msg": message,
+           	"details": metadata,
+           }] {
+           	constraint := input.constraint
+           	lib.get_constraint_params(constraint, params)
+           	asset := input.asset
+           
+           	asset.asset_type == "iam.googleapis.com/Role"
+           
+           	asset_permissions := asset.resource.data.includedPermissions[_]
+           	asset_title := asset.resource.data.title
+           	lower(asset_title) == lower(params.title)
+           
+           	mode := lib.get_default(params, "mode", "allowlist")
+           
+           	matches_found = [m | m = config_pattern(params.permissions[_]); glob.match(m, [], asset_permissions)]
+           	target_match_count(mode, desired_count)
+           	count(matches_found) != desired_count
+           
+           	message := sprintf("Custom role %v grants permission %v", [asset.name, asset_permissions])
+           
+           	metadata := {
+           		"resource": asset.name,
+           		"custom_role_title": asset_title,
+           		"permission": asset_permissions,
+           	}
+           }
+           
+           ###########################
+           # Rule Utilities
+           ###########################
+           
+           # Determine the overlap between matches under test and constraint
+           target_match_count(mode) = 0 {
+           	mode == "denylist"
+           }
+           
+           target_match_count(mode) = 1 {
+           	mode == "allowlist"
+           }
+           
+           # If the member in constraint is written as a single "*", turn it into super
+           # glob "**". Otherwise, we won't be able to match everything.
+           config_pattern(old_pattern) = "**" {
+           	old_pattern == "*"
+           }
+           
+           config_pattern(old_pattern) = old_pattern {
+           	old_pattern != "*"
+           }
+           #ENDINLINE

--- a/samples/iam_custom_role_permissions.yaml
+++ b/samples/iam_custom_role_permissions.yaml
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPIAMCustomRolePermissionsConstraintV1
+metadata:
+  name: allowlist_custom_role_permissions
+  annotations:
+    description: Custom BigQuery role must only have specific permissions
+spec:
+  severity: high
+  parameters:
+    mode: allowlist
+    title: "My Custom BigQuery Role"
+    permissions:
+    - "bigquery.datasets.get"
+    - "bigquery.tables.*"

--- a/samples/iam_custom_role_permissions.yaml
+++ b/samples/iam_custom_role_permissions.yaml
@@ -15,7 +15,7 @@
 apiVersion: constraints.gatekeeper.sh/v1alpha1
 kind: GCPIAMCustomRolePermissionsConstraintV1
 metadata:
-  name: allowlist_custom_role_permissions
+  name: allowlist-custom-role-permissions
   annotations:
     description: Custom BigQuery role must only have specific permissions
 spec:

--- a/validator/iam_custom_role_permissions.rego
+++ b/validator/iam_custom_role_permissions.rego
@@ -30,7 +30,10 @@ deny[{
 
 	asset_permissions := asset.resource.data.includedPermissions[_]
 	asset_title := asset.resource.data.title
-	lower(asset_title) == lower(params.title)
+
+	params_title := lib.get_default(params, "title", "*")
+
+	check_asset_title(asset_title, params_title)
 
 	mode := lib.get_default(params, "mode", "allowlist")
 
@@ -38,11 +41,11 @@ deny[{
 	target_match_count(mode, desired_count)
 	count(matches_found) != desired_count
 
-	message := sprintf("Custom role %v grants permission %v", [asset.name, asset_permissions])
+	message := sprintf("Role %v grants permission %v", [asset.name, asset_permissions])
 
 	metadata := {
 		"resource": asset.name,
-		"custom_role_title": asset_title,
+		"role_title": asset_title,
 		"permission": asset_permissions,
 	}
 }
@@ -58,6 +61,15 @@ target_match_count(mode) = 0 {
 
 target_match_count(mode) = 1 {
 	mode == "allowlist"
+}
+
+check_asset_title(asset_title, params_title) {
+	params_title == "*"
+}
+
+check_asset_title(asset_title, params_title) {
+	params_title != "*"
+	lower(asset_title) == lower(params_title)
 }
 
 # If the member in constraint is written as a single "*", turn it into super

--- a/validator/iam_custom_role_permissions.rego
+++ b/validator/iam_custom_role_permissions.rego
@@ -1,0 +1,71 @@
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package templates.gcp.GCPIAMCustomRolePermissionsConstraintV1
+
+import data.validator.gcp.lib as lib
+
+deny[{
+	"msg": message,
+	"details": metadata,
+}] {
+	constraint := input.constraint
+	lib.get_constraint_params(constraint, params)
+	asset := input.asset
+
+	asset.asset_type == "iam.googleapis.com/Role"
+
+	asset_permissions := asset.resource.data.includedPermissions[_]
+	asset_title := asset.resource.data.title
+	lower(asset_title) == lower(params.title)
+
+	mode := lib.get_default(params, "mode", "allowlist")
+
+	matches_found = [m | m = config_pattern(params.permissions[_]); glob.match(m, [], asset_permissions)]
+	target_match_count(mode, desired_count)
+	count(matches_found) != desired_count
+
+	message := sprintf("Custom role %v grants permission %v", [asset.name, asset_permissions])
+
+	metadata := {
+		"resource": asset.name,
+		"custom_role_title": asset_title,
+		"permission": asset_permissions,
+	}
+}
+
+###########################
+# Rule Utilities
+###########################
+
+# Determine the overlap between matches under test and constraint
+target_match_count(mode) = 0 {
+	mode == "denylist"
+}
+
+target_match_count(mode) = 1 {
+	mode == "allowlist"
+}
+
+# If the member in constraint is written as a single "*", turn it into super
+# glob "**". Otherwise, we won't be able to match everything.
+config_pattern(old_pattern) = "**" {
+	old_pattern == "*"
+}
+
+config_pattern(old_pattern) = old_pattern {
+	old_pattern != "*"
+}

--- a/validator/iam_custom_role_permissions_test.rego
+++ b/validator/iam_custom_role_permissions_test.rego
@@ -50,7 +50,7 @@ test_allowlist_wildcards {
 		"resourcemanager.projects.list",
 	}
 
-	test_utils.check_test_violations_field_names(fixture_assets, [iam_custom_role_permissions_allowlist], template_name, "permission", expected_resource_names)
+	test_utils.check_test_violations_metadata(fixture_assets, [iam_custom_role_permissions_allowlist], template_name, "permission", expected_resource_names)
 }
 
 # Test denylist with wildcards
@@ -77,7 +77,7 @@ test_denylist_wildcards {
 		"resourcemanager.projects.get",
 	}
 
-	test_utils.check_test_violations_field_names(fixture_assets, [iam_custom_role_permissions_denylist], template_name, "permission", expected_resource_names)
+	test_utils.check_test_violations_metadata(fixture_assets, [iam_custom_role_permissions_denylist], template_name, "permission", expected_resource_names)
 }
 
 # Test allowlist for all permissions
@@ -124,7 +124,7 @@ test_denylist_all {
 		"resourcemanager.projects.list",
 	}
 
-	test_utils.check_test_violations_field_names(fixture_assets, [iam_custom_role_permissions_denylist_all], template_name, "permission", expected_resource_names)
+	test_utils.check_test_violations_metadata(fixture_assets, [iam_custom_role_permissions_denylist_all], template_name, "permission", expected_resource_names)
 }
 
 # Test that title name works with different caps case
@@ -147,7 +147,7 @@ test_title_caps {
 		"resourcemanager.projects.list",
 	}
 
-	test_utils.check_test_violations_field_names(fixture_assets, [iam_custom_role_permissions_title_caps], template_name, "permission", expected_resource_names)
+	test_utils.check_test_violations_metadata(fixture_assets, [iam_custom_role_permissions_title_caps], template_name, "permission", expected_resource_names)
 }
 
 # Test for wrong title name
@@ -156,6 +156,29 @@ test_title_wrong {
 }
 
 # Test for no title
-test_title_wrong {
-	test_utils.check_test_violations_count(fixture_assets, [iam_custom_role_permissions_no_title], template_name, 0)
+test_title_none {
+	expected_resource_names := {
+		"bigquery.config.get",
+		"bigquery.jobs.list",
+		"bigquery.models.list",
+		"bigquery.readsessions.create",
+		"bigquery.savedqueries.get",
+		"bigquery.savedqueries.list",
+		"appengine.applications.get",
+		"bigquery.config.update",
+		"cloudsql.instances.clone",
+		"cloudsql.instances.create",
+		"cloudsql.instances.delete",
+		"cloudsql.instances.export",
+		"cloudsql.instances.failover",
+		"cloudsql.instances.getIamPolicy",
+		"cloudsql.instances.import",
+		"compute.disks.list",
+		"compute.disks.resize",
+		"compute.globalOperations.get",
+		"compute.globalOperations.list",
+		"resourcemanager.projects.list",
+	}
+
+	test_utils.check_test_violations_metadata(fixture_assets, [iam_custom_role_permissions_no_title], template_name, "permission", expected_resource_names)
 }

--- a/validator/iam_custom_role_permissions_test.rego
+++ b/validator/iam_custom_role_permissions_test.rego
@@ -1,0 +1,161 @@
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package templates.gcp.GCPIAMCustomRolePermissionsConstraintV1
+
+template_name := "GCPIAMCustomRolePermissionsConstraintV1"
+
+import data.validator.test_utils as test_utils
+
+import data.test.fixtures.iam_custom_role_permissions.assets as fixture_assets
+
+import data.test.fixtures.iam_custom_role_permissions.constraints.iam_custom_role_permissions_allowlist as iam_custom_role_permissions_allowlist
+import data.test.fixtures.iam_custom_role_permissions.constraints.iam_custom_role_permissions_allowlist_all as iam_custom_role_permissions_allowlist_all
+import data.test.fixtures.iam_custom_role_permissions.constraints.iam_custom_role_permissions_denylist as iam_custom_role_permissions_denylist
+import data.test.fixtures.iam_custom_role_permissions.constraints.iam_custom_role_permissions_denylist_all as iam_custom_role_permissions_denylist_all
+import data.test.fixtures.iam_custom_role_permissions.constraints.iam_custom_role_permissions_no_title as iam_custom_role_permissions_no_title
+import data.test.fixtures.iam_custom_role_permissions.constraints.iam_custom_role_permissions_title_caps as iam_custom_role_permissions_title_caps
+import data.test.fixtures.iam_custom_role_permissions.constraints.iam_custom_role_permissions_wrong_title as iam_custom_role_permissions_wrong_title
+
+# Test allowlist with wildcards
+test_allowlist_wildcards {
+	expected_resource_names := {
+		"appengine.applications.get",
+		"bigquery.config.get",
+		"bigquery.config.update",
+		"cloudsql.instances.clone",
+		"cloudsql.instances.create",
+		"cloudsql.instances.delete",
+		"cloudsql.instances.export",
+		"cloudsql.instances.failover",
+		"cloudsql.instances.getIamPolicy",
+		"cloudsql.instances.import",
+		"compute.disks.list",
+		"compute.disks.resize",
+		"compute.globalOperations.get",
+		"compute.globalOperations.list",
+		"resourcemanager.projects.list",
+	}
+
+	test_utils.check_test_violations_field_names(fixture_assets, [iam_custom_role_permissions_allowlist], template_name, "permission", expected_resource_names)
+}
+
+# Test denylist with wildcards
+test_denylist_wildcards {
+	expected_resource_names := {
+		"bigquery.datasets.create",
+		"bigquery.datasets.delete",
+		"bigquery.datasets.get",
+		"cloudsql.instances.get",
+		"compute.images.getFromFamily",
+		"compute.images.list",
+		"compute.images.setLabels",
+		"datastore.entities.allocateIds",
+		"datastore.entities.create",
+		"datastore.entities.delete",
+		"datastore.entities.get",
+		"datastore.entities.list",
+		"datastore.entities.update",
+		"datastore.operations.delete",
+		"datastore.operations.get",
+		"datastore.operations.list",
+		"datastore.statistics.get",
+		"datastore.statistics.list",
+		"resourcemanager.projects.get",
+	}
+
+	test_utils.check_test_violations_field_names(fixture_assets, [iam_custom_role_permissions_denylist], template_name, "permission", expected_resource_names)
+}
+
+# Test allowlist for all permissions
+test_allowlist_all {
+	test_utils.check_test_violations_count(fixture_assets, [iam_custom_role_permissions_allowlist_all], template_name, 0)
+}
+
+# Test denylist for all permissions
+test_denylist_all {
+	expected_resource_names := {
+		"appengine.applications.get",
+		"bigquery.config.get",
+		"bigquery.config.update",
+		"bigquery.datasets.create",
+		"bigquery.datasets.delete",
+		"bigquery.datasets.get",
+		"cloudsql.instances.clone",
+		"cloudsql.instances.create",
+		"cloudsql.instances.delete",
+		"cloudsql.instances.export",
+		"cloudsql.instances.failover",
+		"cloudsql.instances.get",
+		"cloudsql.instances.getIamPolicy",
+		"cloudsql.instances.import",
+		"compute.disks.list",
+		"compute.disks.resize",
+		"compute.globalOperations.get",
+		"compute.globalOperations.list",
+		"compute.images.getFromFamily",
+		"compute.images.list",
+		"compute.images.setLabels",
+		"datastore.entities.allocateIds",
+		"datastore.entities.create",
+		"datastore.entities.delete",
+		"datastore.entities.get",
+		"datastore.entities.list",
+		"datastore.entities.update",
+		"datastore.operations.delete",
+		"datastore.operations.get",
+		"datastore.operations.list",
+		"datastore.statistics.get",
+		"datastore.statistics.list",
+		"resourcemanager.projects.get",
+		"resourcemanager.projects.list",
+	}
+
+	test_utils.check_test_violations_field_names(fixture_assets, [iam_custom_role_permissions_denylist_all], template_name, "permission", expected_resource_names)
+}
+
+# Test that title name works with different caps case
+test_title_caps {
+	expected_resource_names := {
+		"appengine.applications.get",
+		"bigquery.config.get",
+		"bigquery.config.update",
+		"cloudsql.instances.clone",
+		"cloudsql.instances.create",
+		"cloudsql.instances.delete",
+		"cloudsql.instances.export",
+		"cloudsql.instances.failover",
+		"cloudsql.instances.getIamPolicy",
+		"cloudsql.instances.import",
+		"compute.disks.list",
+		"compute.disks.resize",
+		"compute.globalOperations.get",
+		"compute.globalOperations.list",
+		"resourcemanager.projects.list",
+	}
+
+	test_utils.check_test_violations_field_names(fixture_assets, [iam_custom_role_permissions_title_caps], template_name, "permission", expected_resource_names)
+}
+
+# Test for wrong title name
+test_title_wrong {
+	test_utils.check_test_violations_count(fixture_assets, [iam_custom_role_permissions_wrong_title], template_name, 0)
+}
+
+# Test for no title
+test_title_wrong {
+	test_utils.check_test_violations_count(fixture_assets, [iam_custom_role_permissions_no_title], template_name, 0)
+}

--- a/validator/test/fixtures/iam_custom_role_permissions/assets/data.json
+++ b/validator/test/fixtures/iam_custom_role_permissions/assets/data.json
@@ -1,0 +1,93 @@
+[
+  {
+  "name": "//iam.googleapis.com/organizations/123456/roles/test_role_1",
+  "asset_type": "iam.googleapis.com/Role",
+  "resource": {
+    "version": "v1",
+    "discovery_document_uri": "https://iam.googleapis.com/$discovery/rest",
+    "discovery_name": "Role",
+    "parent": "//cloudresourcemanager.googleapis.com/organizations/123456",
+    "data": {
+      "description": "Set this role to test role visibility ",
+      "etag": "BwWJmlmObBw=",
+      "groupName": "custom",
+      "groupTitle": "Custom",
+      "includedPermissions": [
+        "bigquery.config.get",
+        "bigquery.datasets.create",
+        "bigquery.datasets.get",
+        "bigquery.datasets.getIamPolicy",
+        "bigquery.jobs.list",
+        "bigquery.models.list",
+        "bigquery.readsessions.create",
+        "bigquery.savedqueries.get",
+        "bigquery.savedqueries.list"
+      ],
+      "name": "organizations/123456/roles/test_role_1",
+      "stage": "BETA",
+      "title": "Test Role 1"
+    }
+  },
+  "ancestors": [
+    "organizations/123456"
+  ]
+},
+  {
+  "name": "//iam.googleapis.com/organizations/123456/roles/test_role_3",
+  "asset_type": "iam.googleapis.com/Role",
+  "resource": {
+    "version": "v1",
+    "discovery_document_uri": "https://iam.googleapis.com/$discovery/rest",
+    "discovery_name": "Role",
+    "parent": "//cloudresourcemanager.googleapis.com/organizations/123456",
+    "data": {
+      "description": "Created on: 5/16/17",
+      "etag": "BwVPrIoF4pg=",
+      "groupName": "custom",
+      "groupTitle": "Custom",
+      "includedPermissions": [
+        "appengine.applications.get",
+        "bigquery.config.get",
+        "bigquery.config.update",
+        "bigquery.datasets.create",
+        "bigquery.datasets.delete",
+        "bigquery.datasets.get",
+        "cloudsql.instances.clone",
+        "cloudsql.instances.create",
+        "cloudsql.instances.delete",
+        "cloudsql.instances.export",
+        "cloudsql.instances.failover",
+        "cloudsql.instances.get",
+        "cloudsql.instances.getIamPolicy",
+        "cloudsql.instances.import",
+        "compute.disks.list",
+        "compute.disks.resize",
+        "compute.globalOperations.get",
+        "compute.globalOperations.list",
+        "compute.images.getFromFamily",
+        "compute.images.list",
+        "compute.images.setLabels",
+        "datastore.entities.allocateIds",
+        "datastore.entities.create",
+        "datastore.entities.delete",
+        "datastore.entities.get",
+        "datastore.entities.list",
+        "datastore.entities.update",
+        "datastore.operations.delete",
+        "datastore.operations.get",
+        "datastore.operations.list",
+        "datastore.statistics.get",
+        "datastore.statistics.list",
+        "resourcemanager.projects.get",
+        "resourcemanager.projects.list"
+      ],
+      "name": "organizations/123456/roles/test_role_3",
+      "stage": "GA",
+      "title": "Test Role 3"
+    }
+  },
+  "ancestors": [
+    "organizations/123456"
+  ]
+}
+]

--- a/validator/test/fixtures/iam_custom_role_permissions/constraints/iam_custom_role_permissions_allowlist/data.yaml
+++ b/validator/test/fixtures/iam_custom_role_permissions/constraints/iam_custom_role_permissions_allowlist/data.yaml
@@ -1,0 +1,31 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPIAMCustomRolePermissionsConstraintV1
+metadata:
+  name: allowlist_permissions
+  annotations:
+    description: Custom role must only have specific permissions
+spec:
+  severity: high
+  parameters:
+    mode: allowlist
+    title: "Test Role 3"
+    permissions:
+    - "bigquery.datasets.*"
+    - "cloudsql.instances.get"
+    - "compute.images.*"
+    - "datastore.**"
+    - "resourcemanager.projects.get"

--- a/validator/test/fixtures/iam_custom_role_permissions/constraints/iam_custom_role_permissions_allowlist_all/data.yaml
+++ b/validator/test/fixtures/iam_custom_role_permissions/constraints/iam_custom_role_permissions_allowlist_all/data.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPIAMCustomRolePermissionsConstraintV1
+metadata:
+  name: allowlist_permissions_all
+  annotations:
+    description: Custom role can have any permissions
+spec:
+  severity: high
+  parameters:
+    mode: allowlist
+    title: "Test Role 3"
+    permissions:
+    - "*"

--- a/validator/test/fixtures/iam_custom_role_permissions/constraints/iam_custom_role_permissions_denylist/data.yaml
+++ b/validator/test/fixtures/iam_custom_role_permissions/constraints/iam_custom_role_permissions_denylist/data.yaml
@@ -1,0 +1,31 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPIAMCustomRolePermissionsConstraintV1
+metadata:
+  name: denylist_permissions
+  annotations:
+    description: Custom role must not have specific permissions
+spec:
+  severity: high
+  parameters:
+    mode: denylist
+    title: "Test Role 3"
+    permissions:
+    - "bigquery.datasets.*"
+    - "cloudsql.instances.get"
+    - "compute.images.*"
+    - "datastore.**"
+    - "resourcemanager.projects.get"

--- a/validator/test/fixtures/iam_custom_role_permissions/constraints/iam_custom_role_permissions_denylist_all/data.yaml
+++ b/validator/test/fixtures/iam_custom_role_permissions/constraints/iam_custom_role_permissions_denylist_all/data.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPIAMCustomRolePermissionsConstraintV1
+metadata:
+  name: denylist_permissions_all
+  annotations:
+    description: Custom role can not have any permissions
+spec:
+  severity: high
+  parameters:
+    mode: denylist
+    title: "Test Role 3"
+    permissions:
+    - "*"

--- a/validator/test/fixtures/iam_custom_role_permissions/constraints/iam_custom_role_permissions_no_title/data.yaml
+++ b/validator/test/fixtures/iam_custom_role_permissions/constraints/iam_custom_role_permissions_no_title/data.yaml
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPIAMCustomRolePermissionsConstraintV1
+metadata:
+  name: no_title
+spec:
+  severity: high
+  parameters:
+    mode: allowlist
+    permissions:
+    - "bigquery.datasets.*"
+    - "cloudsql.instances.get"
+    - "compute.images.*"
+    - "datastore.**"
+    - "resourcemanager.projects.get"

--- a/validator/test/fixtures/iam_custom_role_permissions/constraints/iam_custom_role_permissions_title_caps/data.yaml
+++ b/validator/test/fixtures/iam_custom_role_permissions/constraints/iam_custom_role_permissions_title_caps/data.yaml
@@ -1,0 +1,31 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPIAMCustomRolePermissionsConstraintV1
+metadata:
+  name: allowlist_permissions_title_caps
+  annotations:
+    description: Custom role must only have specific permissions
+spec:
+  severity: high
+  parameters:
+    mode: allowlist
+    title: "tesT rOLE 3"
+    permissions:
+    - "bigquery.datasets.*"
+    - "cloudsql.instances.get"
+    - "compute.images.*"
+    - "datastore.**"
+    - "resourcemanager.projects.get"

--- a/validator/test/fixtures/iam_custom_role_permissions/constraints/iam_custom_role_permissions_wrong_title/data.yaml
+++ b/validator/test/fixtures/iam_custom_role_permissions/constraints/iam_custom_role_permissions_wrong_title/data.yaml
@@ -1,0 +1,31 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPIAMCustomRolePermissionsConstraintV1
+metadata:
+  name: allowlist_permissions_caps_wrong_title
+  annotations:
+    description: Custom role must only have specific permissions
+spec:
+  severity: high
+  parameters:
+    mode: allowlist
+    title: "Wrong Test Title"
+    permissions:
+    - "bigquery.datasets.*"
+    - "cloudsql.instances.get"
+    - "compute.images.*"
+    - "datastore.**"
+    - "resourcemanager.projects.get"

--- a/validator/test_utils.rego
+++ b/validator/test_utils.rego
@@ -40,6 +40,13 @@ check_test_violations_resources(test_assets, test_constraints, test_template, ex
 	resource_names == expected_resource_names
 }
 
+# This is to check for other field names from violations besides resource
+check_test_violations_field_names(test_assets, test_constraints, test_template, field_name, expected_resource_names) {
+	violations := get_test_violations(test_assets, test_constraints, test_template)
+	resource_names := {x | x = violations[_].details[field_name]}
+	resource_names == expected_resource_names
+}
+
 check_test_violations_signature(test_assets, test_constraints, test_template) {
 	violations := get_test_violations(test_assets, test_constraints, test_template)
 	violation := violations[_]

--- a/validator/test_utils.rego
+++ b/validator/test_utils.rego
@@ -41,10 +41,10 @@ check_test_violations_resources(test_assets, test_constraints, test_template, ex
 }
 
 # This is to check for other field names from violations besides resource
-check_test_violations_field_names(test_assets, test_constraints, test_template, field_name, expected_resource_names) {
+check_test_violations_metadata(test_assets, test_constraints, test_template, field_name, field_values) {
 	violations := get_test_violations(test_assets, test_constraints, test_template)
 	resource_names := {x | x = violations[_].details[field_name]}
-	resource_names == expected_resource_names
+	resource_names == field_values
 }
 
 check_test_violations_signature(test_assets, test_constraints, test_template) {


### PR DESCRIPTION
### IAM Custom Role Permissions Constraint V1

This PR creates an IAM Policy Custom Role Permissions constraint that checks whether the user defined permissions are either allowed or denied in a user defined custom role.

A sample playground for this constraint is provided [here](https://play.openpolicyagent.org/p/U4DDvP39H1).

### This constraint provides the following features:

1. **mode**
- Enforcement mode, [denylist, allowlist] , defaults to allowlist.
2. **title**
- The custom role title to scan for, found on the IAM Roles page.
    - E.g. 'My Custom Role for BigQuery'
3. **permissions**
- Permissions to either allow or deny for the given custom role, depending on mode; Wildcards (*) supported.
    - E.g. 'bigquery.datasets.*' will search for any permissions that start with bigquery.datasets, such as bigquery.datasets.get
    - E.g. 'bigquery.**' will search for any permissions that start with bigquery, such as bigquery.savedqueries.get, bigquery.config.get
    - E.g. '*' will search for any permissions

### Also included in this PR:

- Sample constraint
- Tests
- Added a function to `test_utils` to test for a field other than `resource`.