### PR TITLE
Add in assetNames parameter to IAM Allowed Bindings Constraint

### DIFF
--- a/policies/templates/gcp_iam_allowed_bindings_v1.yaml
+++ b/policies/templates/gcp_iam_allowed_bindings_v1.yaml
@@ -31,6 +31,13 @@ spec:
             assetType:
               description: "Restrict which asset type this policy applies to"
               type: string
+            assetNames:
+              description: "CAI name of asset to restrict which specific assets this policy applies to.
+              assetNames must have the same assetType defined above.
+              E.g. '//bigquery.googleapis.com/projects/my-project/datasets/my-dataset'"
+              type: array
+              items:
+                type: string
             role:
               description: "Role to restrict bindings for,
                 ex. roles/owner; Wildcards (*) supported"
@@ -45,7 +52,7 @@ spec:
    validation.gcp.forsetisecurity.org:
       rego: | #INLINE("validator/iam_allowed_bindings.rego")
             #
-            # Copyright 2019 Google LLC
+            # Copyright 2020 Google LLC
             #
             # Licensed under the Apache License, Version 2.0 (the "License");
             # you may not use this file except in compliance with the License.
@@ -73,6 +80,10 @@ spec:
             	asset := input.asset
             
             	check_asset_type(asset, params)
+            
+            	# Check if resource is part of asset names to scan
+            	include_list := lib.get_default(params, "assetNames", [])
+            	is_included(include_list, asset.name)
             
             	binding := asset.iam_policy.bindings[_]
             	member := binding.members[_]
@@ -115,6 +126,15 @@ spec:
             
             check_asset_type(asset, params) {
             	lib.has_field(params, "assetType") == false
+            }
+            
+            is_included(include_list, asset_name) {
+            	include_list != []
+            	glob.match(include_list[_], ["/"], asset_name)
+            }
+            
+            is_included(include_list, asset_name) {
+            	include_list == []
             }
             
             # If the member in constraint is written as a single "*", turn it into super

--- a/samples/iam_restrict_googlegroups_bigquery_dataset.yaml
+++ b/samples/iam_restrict_googlegroups_bigquery_dataset.yaml
@@ -27,6 +27,7 @@ spec:
   parameters:
     mode: blacklist
     assetType: bigquery.googleapis.com/Dataset
+    assetNames: []
     role: roles/*
     members:
     - "user:*@googlegroups.com"

--- a/validator/iam_allowed_bindings.rego
+++ b/validator/iam_allowed_bindings.rego
@@ -1,5 +1,5 @@
 #
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,6 +27,10 @@ deny[{
 	asset := input.asset
 
 	check_asset_type(asset, params)
+
+	# Check if resource is part of asset names to scan
+	include_list := lib.get_default(params, "assetNames", [])
+	is_included(include_list, asset.name)
 
 	binding := asset.iam_policy.bindings[_]
 	member := binding.members[_]
@@ -69,6 +73,15 @@ check_asset_type(asset, params) {
 
 check_asset_type(asset, params) {
 	lib.has_field(params, "assetType") == false
+}
+
+is_included(include_list, asset_name) {
+	include_list != []
+	glob.match(include_list[_], ["/"], asset_name)
+}
+
+is_included(include_list, asset_name) {
+	include_list == []
 }
 
 # If the member in constraint is written as a single "*", turn it into super

--- a/validator/iam_allowed_bindings_test.rego
+++ b/validator/iam_allowed_bindings_test.rego
@@ -57,11 +57,16 @@ test_whitelist_role_violation_count {
 
 # Test blacklist to BigQuery dataset for gmail.com addresses
 test_restrict_gmail_bigquery_dataset_violations_count {
-	test_utils.check_test_violations_count(fixture_assets, [fixture_constraints.iam_allowed_bindings_blacklist_gmail_bigquery_dataset], template_name, 2)
+	test_utils.check_test_violations_count(fixture_assets, [fixture_constraints.iam_allowed_bindings_blacklist_gmail_bigquery_dataset], template_name, 6)
 }
 
 test_restrict_gmail_bigquery_dataset_resources {
-	resource_names := {"//bigquery.googleapis.com/projects/12345/datasets/testdataset1"}
+	resource_names := {
+		"//bigquery.googleapis.com/projects/12345/datasets/testdataset1",
+		"//bigquery.googleapis.com/projects/12345/datasets/testdataset3",
+		"//bigquery.googleapis.com/projects/12345/datasets/testdataset4",
+	}
+
 	test_utils.check_test_violations_resources(fixture_assets, [fixture_constraints.iam_allowed_bindings_blacklist_gmail_bigquery_dataset], template_name, resource_names)
 }
 
@@ -73,4 +78,14 @@ test_restrict_googlegroups_bigquery_dataset_violations_count {
 test_restrict_googlegroups_bigquery_dataset_resources {
 	resource_names := {"//bigquery.googleapis.com/projects/12345/datasets/testdataset2"}
 	test_utils.check_test_violations_resources(fixture_assets, [fixture_constraints.iam_allowed_bindings_blacklist_googlegroups_bigquery_dataset], template_name, resource_names)
+}
+
+# Test blacklist to specific BigQuery dataset for gmail.com addresses
+test_restrict_gmail_specific_bigquery_dataset_violations_count {
+	test_utils.check_test_violations_count(fixture_assets, [fixture_constraints.iam_allowed_bindings_blacklist_asset_names], template_name, 4)
+}
+
+# Test whitelist to specific BigQuery dataset for gmail.com addresses
+test_restrict_gmail_specific_bigquery_dataset_violations_count {
+	test_utils.check_test_violations_count(fixture_assets, [fixture_constraints.iam_allowed_bindings_whitelist_asset_names], template_name, 0)
 }

--- a/validator/test/fixtures/iam_allowed_bindings/assets/data.json
+++ b/validator/test/fixtures/iam_allowed_bindings/assets/data.json
@@ -98,5 +98,49 @@
                 }
             ]
         }
+    },
+    {
+        "name": "//bigquery.googleapis.com/projects/12345/datasets/testdataset3",
+        "asset_type": "bigquery.googleapis.com/Dataset",
+        "iam_policy": {
+            "version": 1,
+            "etag": "CdWC1qPLfdw=",
+            "bindings": [
+                {
+                    "role": "roles/bigquery.dataViewer",
+                    "members": [
+                        "user:user@gmail.com"
+                    ]
+                },
+                {
+                    "role": "roles/bigquery.dataOwner",
+                    "members": [
+                        "user:admin@gmail.com"
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "name": "//bigquery.googleapis.com/projects/12345/datasets/testdataset4",
+        "asset_type": "bigquery.googleapis.com/Dataset",
+        "iam_policy": {
+            "version": 1,
+            "etag": "CdWC1qPLfdw=",
+            "bindings": [
+                {
+                    "role": "roles/bigquery.dataViewer",
+                    "members": [
+                        "user:user@gmail.com"
+                    ]
+                },
+                {
+                    "role": "roles/bigquery.dataOwner",
+                    "members": [
+                        "user:admin@gmail.com"
+                    ]
+                }
+            ]
+        }
     }
 ]

--- a/validator/test/fixtures/iam_allowed_bindings/constraints/iam_allowed_bindings_blacklist_asset_names/data.yaml
+++ b/validator/test/fixtures/iam_allowed_bindings/constraints/iam_allowed_bindings_blacklist_asset_names/data.yaml
@@ -15,19 +15,17 @@
 apiVersion: constraints.gatekeeper.sh/v1alpha1
 kind: GCPIAMAllowedBindingsConstraintV1
 metadata:
-  name: blacklist-gmail-bigquery-dataset
+  name: blacklist-gmail-specific-bigquery-dataset
   annotations:
-    description: Enforce corporate domain by banning gmail.com addresses access to BigQuery datasets
-    bundles.validator.forsetisecurity.org/forseti-security: v2.26.0
+    description: Enforce corporate domain by banning gmail.com addresses access to specific BigQuery datasets
 spec:
   severity: high
-  match:
-    target: ["organization/*"]
-    exclude: []
   parameters:
     mode: blacklist
     assetType: bigquery.googleapis.com/Dataset
-    assetNames: []
+    assetNames:
+      - "//bigquery.googleapis.com/projects/12345/datasets/testdataset1"
+      - "//bigquery.googleapis.com/projects/12345/datasets/testdataset3"
     role: roles/*
     members:
-    - "user:*@gmail.com"
+      - "user:*@gmail.com"

--- a/validator/test/fixtures/iam_allowed_bindings/constraints/iam_allowed_bindings_whitelist_asset_names/data.yaml
+++ b/validator/test/fixtures/iam_allowed_bindings/constraints/iam_allowed_bindings_whitelist_asset_names/data.yaml
@@ -15,19 +15,17 @@
 apiVersion: constraints.gatekeeper.sh/v1alpha1
 kind: GCPIAMAllowedBindingsConstraintV1
 metadata:
-  name: blacklist-gmail-bigquery-dataset
+  name: whitelist-gmail-specific-bigquery-dataset
   annotations:
-    description: Enforce corporate domain by banning gmail.com addresses access to BigQuery datasets
-    bundles.validator.forsetisecurity.org/forseti-security: v2.26.0
+    description: Enforce corporate domain by only allowing gmail.com addresses access to specific BigQuery datasets
 spec:
   severity: high
-  match:
-    target: ["organization/*"]
-    exclude: []
   parameters:
-    mode: blacklist
+    mode: whitelist
     assetType: bigquery.googleapis.com/Dataset
-    assetNames: []
+    assetNames:
+      - "//bigquery.googleapis.com/projects/12345/datasets/testdataset1"
+      - "//bigquery.googleapis.com/projects/12345/datasets/testdataset3"
     role: roles/*
     members:
-    - "user:*@gmail.com"
+      - "user:*@gmail.com"


### PR DESCRIPTION
Resolves #330 

Add in assetNames parameter to [IAM Allowed Bindings Constraint](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_iam_allowed_bindings_v1.yaml) in order to target specific assets vs. project/folder/organization wide.

This is an optional parameter- default will be [], so no version upgrade is required.

Also included in this PR:
- Tests
- Updated samples