### PR TITLE
Add in assetNames parameter to IAM Required Bindings Constraint

### DIFF
--- a/policies/templates/gcp_iam_required_bindings_v1.yaml
+++ b/policies/templates/gcp_iam_required_bindings_v1.yaml
@@ -28,6 +28,13 @@ spec:
               description: "Restrict which asset type this policy applies to.
               E.g. cloudresourcemanager.googleapis.com/Project would restrict to only Project resources"
               type: string
+            assetNames:
+              description: "CAI name of asset to restrict which specific assets this policy applies to.
+              assetNames must have the same assetType defined above.
+              E.g. '//cloudresourcemanager.googleapis.com/projects/project-123'"
+              type: array
+              items:
+                type: string
             role:
               description: "Role to restrict bindings for. Wildcards (*) supported.
               E.g. roles/owner would only look at bindings for the owner role.
@@ -75,6 +82,10 @@ spec:
            
            	check_asset_type(asset, params)
            
+           	# Check if resource is part of asset names to scan
+           	include_list := lib.get_default(params, "assetNames", [])
+           	is_included(include_list, asset.name)
+           
            	binding := asset.iam_policy.bindings[_]
            	role := binding.role
            
@@ -115,6 +126,15 @@ spec:
            
            check_asset_type(asset, params) {
            	lib.has_field(params, "assetType") == false
+           }
+           
+           is_included(include_list, asset_name) {
+           	include_list != []
+           	glob.match(include_list[_], ["/"], asset_name)
+           }
+           
+           is_included(include_list, asset_name) {
+           	include_list == []
            }
            
            # If the member in constraint is written as a single "*", turn it into super

--- a/validator/iam_required_bindings.rego
+++ b/validator/iam_required_bindings.rego
@@ -28,6 +28,10 @@ deny[{
 
 	check_asset_type(asset, params)
 
+	# Check if resource is part of asset names to scan
+	include_list := lib.get_default(params, "assetNames", [])
+	is_included(include_list, asset.name)
+
 	binding := asset.iam_policy.bindings[_]
 	role := binding.role
 
@@ -68,6 +72,15 @@ check_asset_type(asset, params) {
 
 check_asset_type(asset, params) {
 	lib.has_field(params, "assetType") == false
+}
+
+is_included(include_list, asset_name) {
+	include_list != []
+	glob.match(include_list[_], ["/"], asset_name)
+}
+
+is_included(include_list, asset_name) {
+	include_list == []
 }
 
 # If the member in constraint is written as a single "*", turn it into super

--- a/validator/iam_required_bindings_test.rego
+++ b/validator/iam_required_bindings_test.rego
@@ -26,7 +26,7 @@ template_name := "GCPIAMRequiredBindingsConstraintV1"
 require_role_domain_violations := test_utils.get_test_violations(fixture_assets, [fixture_constraints.iam_required_bindings_role_domain], template_name)
 
 test_require_role_domain_violations {
-	count(require_role_domain_violations) = 2
+	count(require_role_domain_violations) = 3
 	violation := require_role_domain_violations[_]
 	violation.details.role == "roles/owner"
 	violation.details.required_member == "user:*@required-group.com"
@@ -36,7 +36,7 @@ test_require_role_domain_violations {
 require_role_member_violations := test_utils.get_test_violations(fixture_assets, [fixture_constraints.iam_required_bindings_role_members], template_name)
 
 test_require_role_member_violations {
-	count(require_role_member_violations) = 2
+	count(require_role_member_violations) = 3
 	violation := require_role_member_violations[_]
 	violation.details.role == "roles/owner"
 	violation.details.required_member == "user:required@notgoogle.com"
@@ -44,7 +44,7 @@ test_require_role_member_violations {
 
 # Test that only Project resources are parsed
 test_require_project_violations {
-	test_utils.check_test_violations_count(fixture_assets, [fixture_constraints.iam_required_bindings_project], template_name, 3)
+	test_utils.check_test_violations_count(fixture_assets, [fixture_constraints.iam_required_bindings_project], template_name, 6)
 }
 
 # Test for no violations
@@ -55,4 +55,9 @@ test_require_role_no_violations {
 # Test with empty members params
 test_require_role_no_violations {
 	test_utils.check_test_violations_count(fixture_assets, [fixture_constraints.iam_required_bindings_none], template_name, 0)
+}
+
+# Test that only specific Project resource asset names are parsed
+test_require_project_violations_asset_name {
+	test_utils.check_test_violations_count(fixture_assets, [fixture_constraints.iam_required_bindings_project_asset_name], template_name, 3)
 }

--- a/validator/test/fixtures/iam_required_bindings/assets/data.json
+++ b/validator/test/fixtures/iam_required_bindings/assets/data.json
@@ -54,5 +54,38 @@
                 }
             ]
         }
+    },
+    {
+        "name": "//cloudresourcemanager.googleapis.com/projects/12345-2",
+        "asset_type": "cloudresourcemanager.googleapis.com/Project",
+        "iam_policy": {
+            "version": 1,
+            "etag": "CdWC1qPLfdw=",
+            "bindings": [
+                {
+                    "role": "roles/iam.serviceAccountUser",
+                    "members": [
+                        "user:bad@notgoogle.com",
+                        "serviceAccount:service-12345@notiam.gserviceaccount.com"
+                    ]
+                },
+                {
+                    "role": "roles/owner",
+                    "members": [
+                        "user:powerful@google.com",
+                        "group:admins@google.com",
+                        "user:evil@notgoogle.com"
+                    ]
+                },
+                {
+                    "role": "roles/viewer",
+                    "members": [
+                        "allUsers",
+                        "allAuthenticatedUsers",
+                        "user:okay@google.com"
+                    ]
+                }
+            ]
+        }
     }
 ]

--- a/validator/test/fixtures/iam_required_bindings/constraints/iam_required_bindings_project_asset_name/data.yaml
+++ b/validator/test/fixtures/iam_required_bindings/constraints/iam_required_bindings_project_asset_name/data.yaml
@@ -8,7 +8,8 @@ spec:
   severity: high
   parameters:
     assetType: cloudresourcemanager.googleapis.com/Project
-    assetNames: []
+    assetNames:
+      - "//cloudresourcemanager.googleapis.com/projects/12345-2"
     role: "roles/*"
     members:
     - "user:required@google.com"


### PR DESCRIPTION
Related to #330 

Add in assetNames parameter to [IAM Required Bindings Constraint](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_iam_required_bindings_v1.yaml) in order to target specific assets vs. project/folder/organization wide.

This is an optional parameter- default will be [], so no version upgrade is required.

Also included in this PR:
- Tests