### PR TITLE
Support UUID in export operations

### DIFF
--- a/scripts/cft.sh
+++ b/scripts/cft.sh
@@ -163,8 +163,8 @@ export_cai_nonforseti(){
     type="projects"
   fi
 
-  regex_resource="gcloud asset operations describe $type/[0-9]*/operations/ExportAssets/RESOURCE/[0-9]*"
-  regex_iam="gcloud asset operations describe $type/[0-9]*/operations/ExportAssets/IAM_POLICY/[0-9]*"
+  regex_resource="gcloud asset operations describe $type/[0-9]*/operations/ExportAssets/RESOURCE/[0-9a-f\-]*"
+  regex_iam="gcloud asset operations describe $type/[0-9]*/operations/ExportAssets/IAM_POLICY/[0-9a-f\-]*"
 
   poll_resource=$(echo $output_resource | grep -oh "$regex_resource")
   poll_iam=$(echo $output_iam | grep -oh "$regex_iam")


### PR DESCRIPTION
I was getting mix of number and UUID IDs in my case. This is an example output of `asset export` command:

```
Export in progress for root asset [organizations/<ORG_ID>].
Step #0: Use [gcloud asset operations describe organizations/<ORG_ID>/operations/ExportAssets/IAM_POLICY/5eb459b4-0000-2057-ad4a-883d24f377b8] to check the status of the operation.
```

According to the doco it could be UUID as well: https://cloud.google.com/asset-inventory/docs/exporting-to-cloud-storage#exporting_an_asset_snapshot