### PR TITLE
Support for ip_alias constraint with 3.0+ google providers.

### DIFF
--- a/policies/templates/gcp_gke_enable_alias_ip_ranges.yaml
+++ b/policies/templates/gcp_gke_enable_alias_ip_ranges.yaml
@@ -69,8 +69,18 @@ spec:
             # Rule Utilities
             ###########################
             alias_ip_ranges_disabled(cluster) {
+            	# Has ipAllocationPolicyField, and useIpAliases is false
+            	ipAllocationPolicyField := lib.has_field(cluster, "ipAllocationPolicy")
+            	ipAllocationPolicyField == true
+            
             	ipAllocationPolicy := lib.get_default(cluster, "ipAllocationPolicy", {})
-            	useIpAliases := lib.get_default(ipAllocationPolicy, "useIpAliases", false)
+            	useIpAliases := lib.get_default(ipAllocationPolicy, "useIpAliases", true)
             	useIpAliases != true
+            }
+            
+            alias_ip_ranges_disabled(cluster) {
+            	# Doesn't have ipAllocationPolicyField
+            	ipAllocationPolicy := lib.has_field(cluster, "ipAllocationPolicy")
+            	ipAllocationPolicy != true
             }
             #ENDINLINE

--- a/validator/gke_enable_alias_ip_ranges.rego
+++ b/validator/gke_enable_alias_ip_ranges.rego
@@ -37,7 +37,17 @@ deny[{
 # Rule Utilities
 ###########################
 alias_ip_ranges_disabled(cluster) {
+	# Has ipAllocationPolicyField, and useIpAliases is false
+	ipAllocationPolicyField := lib.has_field(cluster, "ipAllocationPolicy")
+	ipAllocationPolicyField == true
+
 	ipAllocationPolicy := lib.get_default(cluster, "ipAllocationPolicy", {})
-	useIpAliases := lib.get_default(ipAllocationPolicy, "useIpAliases", false)
+	useIpAliases := lib.get_default(ipAllocationPolicy, "useIpAliases", true)
 	useIpAliases != true
+}
+
+alias_ip_ranges_disabled(cluster) {
+	# Doesn't have ipAllocationPolicyField
+	ipAllocationPolicy := lib.has_field(cluster, "ipAllocationPolicy")
+	ipAllocationPolicy != true
 }

--- a/validator/gke_enable_alias_ip_ranges_test.rego
+++ b/validator/gke_enable_alias_ip_ranges_test.rego
@@ -17,24 +17,23 @@
 package templates.gcp.GCPGKEEnableAliasIPRangesConstraintV1
 
 import data.validator.gcp.lib as lib
+import data.validator.test_utils as test_utils
 
-all_violations[violation] {
-	resource := data.test.fixtures.gke_enable_alias_ip_ranges.assets[_]
-	constraint := data.test.fixtures.gke_enable_alias_ip_ranges.constraints.enable_alias_ip_ranges
+# Import the test data
+import data.test.fixtures.gke_enable_alias_ip_ranges.assets as fixture_data
 
-	issues := deny with input.asset as resource
-		 with input.constraint as constraint
+# Importing the test constraint
+import data.test.fixtures.gke_enable_alias_ip_ranges.constraints as fixture_constraints
 
-	violation := issues[_]
-}
+template_name := "GCPGKEEnableAliasIPRangesConstraintV1"
 
-test_alias_ip_ranges_enabled {
-	violation := all_violations[_]
-	resource_names := {x | x = all_violations[_].details.resource}
-	not resource_names["//container.googleapis.com/projects/transfer-repos/zones/us-central1-c/clusters/joe-clust"]
-}
+test_enforce_gke_enable_ip_ranges_violations {
+	expected_resource_names := {
+		"//container.googleapis.com/projects/transfer-repos/zones/us-central1-c/clusters/joe-clust2",
+		"//container.googleapis.com/projects/transfer-repos/zones/us-central1-c/clusters/route-based-3",
+	}
 
-test_alias_ip_ranges_disabled {
-	violation := all_violations[_]
-	violation.details.resource == "//container.googleapis.com/projects/transfer-repos/zones/us-central1-c/clusters/joe-clust2"
+	test_utils.check_test_violations_count(fixture_data, [fixture_constraints], template_name, 2)
+	test_utils.check_test_violations_resources(fixture_data, [fixture_constraints], template_name, expected_resource_names)
+	test_utils.check_test_violations_signature(fixture_data, [fixture_constraints], template_name)
 }

--- a/validator/test/fixtures/gke_enable_alias_ip_ranges/assets/data.json
+++ b/validator/test/fixtures/gke_enable_alias_ip_ranges/assets/data.json
@@ -222,5 +222,215 @@
         "zone": "us-central1-a"
       }
     }
+  },
+  {
+    "name": "//container.googleapis.com/projects/transfer-repos/zones/us-central1-c/clusters/route-based-3",
+    "asset_type": "container.googleapis.com/Cluster",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://container.googleapis.com/$discovery/rest",
+      "discovery_name": "Cluster",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/282148707733",
+      "data": {
+        "addonsConfig": {
+          "horizontalPodAutoscaling": {},
+          "httpLoadBalancing": {},
+          "kubernetesDashboard": {
+            "disabled": true
+          },
+          "networkPolicyConfig": {
+            "disabled": true
+          }
+        },
+        "clusterIpv4Cidr": "10.8.0.0/14",
+        "createTime": "2019-06-10T19:53:56+00:00",
+        "currentMasterVersion": "1.12.8-gke.6",
+        "currentNodeCount": 3,
+        "currentNodeVersion": "1.12.8-gke.6",
+        "defaultMaxPodsConstraint": {
+          "maxPodsPerNode": "110"
+        },
+        "endpoint": "130.211.231.220",
+        "initialClusterVersion": "1.12.8-gke.6",
+        "instanceGroupUrls": [
+          "https://www.googleapis.com/compute/v1/projects/transfer-repos/zones/us-central1-a/instanceGroupManagers/gke-joe-clust2-default-pool-5b754b0f-grp"
+        ],
+        "labelFingerprint": "a9dc16a7",
+        "legacyAbac": {},
+        "location": "us-central1-a",
+        "locations": [
+          "us-central1-a"
+        ],
+        "loggingService": "logging.googleapis.com",
+        "masterAuthorizedNetworksConfig": {
+          "enabled": true
+        },
+        "monitoringService": "monitoring.googleapis.com",
+        "name": "joe-clust2",
+        "network": "default",
+        "networkConfig": {
+          "network": "projects/transfer-repos/global/networks/default",
+          "subnetwork": "projects/transfer-repos/regions/us-central1/subnetworks/default"
+        },
+        "networkPolicy": {},
+        "nodePools": [
+          {
+            "autoscaling": {},
+            "config": {
+              "diskSizeGb": 100,
+              "diskType": "pd-standard",
+              "imageType": "COS",
+              "machineType": "n1-standard-1",
+              "metadata": {
+                "disable-legacy-endpoints": "true"
+              },
+              "oauthScopes": [
+                "https://www.googleapis.com/auth/devstorage.read_only",
+                "https://www.googleapis.com/auth/logging.write",
+                "https://www.googleapis.com/auth/monitoring",
+                "https://www.googleapis.com/auth/servicecontrol",
+                "https://www.googleapis.com/auth/service.management.readonly",
+                "https://www.googleapis.com/auth/trace.append"
+              ],
+              "serviceAccount": "default"
+            },
+            "initialNodeCount": 3,
+            "instanceGroupUrls": [
+              "https://www.googleapis.com/compute/v1/projects/transfer-repos/zones/us-central1-a/instanceGroupManagers/gke-joe-clust2-default-pool-5b754b0f-grp"
+            ],
+            "management": {
+              "autoRepair": true,
+              "autoUpgrade": true
+            },
+            "maxPodsConstraint": {
+              "maxPodsPerNode": "110"
+            },
+            "name": "default-pool",
+            "podIpv4CidrSize": 24,
+            "selfLink": "https://container.googleapis.com/v1/projects/transfer-repos/zones/us-central1-a/clusters/joe-clust2/nodePools/default-pool",
+            "status": "RUNNING",
+            "version": "1.12.8-gke.6"
+          }
+        ],
+        "privateClusterConfig": {
+          "enablePrivateNodes": true,
+          "masterIpv4CidrBlock": "172.16.0.0/28",
+          "privateEndpoint": "172.16.0.2",
+          "publicEndpoint": "130.211.231.220"
+        },
+        "selfLink": "https://container.googleapis.com/v1/projects/transfer-repos/zones/us-central1-a/clusters/joe-clust2",
+        "servicesIpv4Cidr": "10.12.0.0/20",
+        "status": "RUNNING",
+        "subnetwork": "default",
+        "zone": "us-central1-a"
+      }
+    }
+  },
+  {
+    "name": "//container.googleapis.com/projects/transfer-repos/zones/us-central1-c/clusters/alias-ip-3",
+    "asset_type": "container.googleapis.com/Cluster",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://container.googleapis.com/$discovery/rest",
+      "discovery_name": "Cluster",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/282148707733",
+      "data": {
+        "addonsConfig": {
+          "horizontalPodAutoscaling": {},
+          "httpLoadBalancing": {},
+          "kubernetesDashboard": {
+            "disabled": true
+          },
+          "networkPolicyConfig": {
+            "disabled": true
+          }
+        },
+        "clusterIpv4Cidr": "10.8.0.0/14",
+        "createTime": "2019-06-10T19:53:56+00:00",
+        "currentMasterVersion": "1.12.8-gke.6",
+        "currentNodeCount": 3,
+        "currentNodeVersion": "1.12.8-gke.6",
+        "defaultMaxPodsConstraint": {
+          "maxPodsPerNode": "110"
+        },
+        "endpoint": "130.211.231.220",
+        "initialClusterVersion": "1.12.8-gke.6",
+        "instanceGroupUrls": [
+          "https://www.googleapis.com/compute/v1/projects/transfer-repos/zones/us-central1-a/instanceGroupManagers/gke-joe-clust2-default-pool-5b754b0f-grp"
+        ],
+        "ipAllocationPolicy": {
+          "clusterIpv4Cidr": "10.8.0.0/14",
+          "servicesIpv4Cidr": "10.12.0.0/20"
+        },
+        "labelFingerprint": "a9dc16a7",
+        "legacyAbac": {},
+        "location": "us-central1-a",
+        "locations": [
+          "us-central1-a"
+        ],
+        "loggingService": "logging.googleapis.com",
+        "masterAuthorizedNetworksConfig": {
+          "enabled": true
+        },
+        "monitoringService": "monitoring.googleapis.com",
+        "name": "joe-clust2",
+        "network": "default",
+        "networkConfig": {
+          "network": "projects/transfer-repos/global/networks/default",
+          "subnetwork": "projects/transfer-repos/regions/us-central1/subnetworks/default"
+        },
+        "networkPolicy": {},
+        "nodePools": [
+          {
+            "autoscaling": {},
+            "config": {
+              "diskSizeGb": 100,
+              "diskType": "pd-standard",
+              "imageType": "COS",
+              "machineType": "n1-standard-1",
+              "metadata": {
+                "disable-legacy-endpoints": "true"
+              },
+              "oauthScopes": [
+                "https://www.googleapis.com/auth/devstorage.read_only",
+                "https://www.googleapis.com/auth/logging.write",
+                "https://www.googleapis.com/auth/monitoring",
+                "https://www.googleapis.com/auth/servicecontrol",
+                "https://www.googleapis.com/auth/service.management.readonly",
+                "https://www.googleapis.com/auth/trace.append"
+              ],
+              "serviceAccount": "default"
+            },
+            "initialNodeCount": 3,
+            "instanceGroupUrls": [
+              "https://www.googleapis.com/compute/v1/projects/transfer-repos/zones/us-central1-a/instanceGroupManagers/gke-joe-clust2-default-pool-5b754b0f-grp"
+            ],
+            "management": {
+              "autoRepair": true,
+              "autoUpgrade": true
+            },
+            "maxPodsConstraint": {
+              "maxPodsPerNode": "110"
+            },
+            "name": "default-pool",
+            "podIpv4CidrSize": 24,
+            "selfLink": "https://container.googleapis.com/v1/projects/transfer-repos/zones/us-central1-a/clusters/joe-clust2/nodePools/default-pool",
+            "status": "RUNNING",
+            "version": "1.12.8-gke.6"
+          }
+        ],
+        "privateClusterConfig": {
+          "enablePrivateNodes": true,
+          "masterIpv4CidrBlock": "172.16.0.0/28",
+          "privateEndpoint": "172.16.0.2",
+          "publicEndpoint": "130.211.231.220"
+        },
+        "selfLink": "https://container.googleapis.com/v1/projects/transfer-repos/zones/us-central1-a/clusters/joe-clust2",
+        "servicesIpv4Cidr": "10.12.0.0/20",
+        "status": "RUNNING",
+        "subnetwork": "default",
+        "zone": "us-central1-a"
+      }
+    }
   }
 ]


### PR DESCRIPTION
The field use_ip_alias has been removed from the google provider. This causes the constraint to fail on clusters that have ip alias enabled.

According to the changelog, the new indication of a route-based cluster is the missing ip_allocation policy block. I updated the constraint to use the new system.

https://www.terraform.io/docs/providers/google/guides/version_3_upgrade.html#ip_allocation_policy-will-catch-out-of-band-changes-use_ip_aliases-removed
