### PR TITLE
Pluralize examples and update docs.

### DIFF
--- a/docs/constraint_template_authoring.md
+++ b/docs/constraint_template_authoring.md
@@ -208,7 +208,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mode: "whitelist"
     instances:

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -167,31 +167,31 @@ For example:
    </td>
   </tr>
   <tr>
-   <td>organization/*
+   <td>organizations/**
    </td>
    <td>All organizations
    </td>
   </tr>
   <tr>
-   <td>organization/123/*
+   <td>organizations/123/**
    </td>
    <td>Everything in organization 123
    </td>
   </tr>
   <tr>
-   <td>organization/123/folder/*
+   <td>organizations/123/folders/**
    </td>
    <td>Everything in organization 123 that is under a folder
    </td>
   </tr>
   <tr>
-   <td>organization/123/folder/456
+   <td>organizations/123/folders/456
    </td>
    <td>Everything in folder 456 in organization 123
    </td>
   </tr>
   <tr>
-   <td>organization/123/folder/456/project/789
+   <td>organizations/123/folders/456/projects/789
    </td>
    <td>Everything in project 789 in folder 456 in organization 123
    </td>
@@ -245,7 +245,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mode: "whitelist"
     instances:
@@ -390,7 +390,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     domains:
       - gserviceaccount.com
@@ -457,7 +457,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     domains:
       - gserviceaccount.com

--- a/samples/allowed_resource_types.yaml
+++ b/samples/allowed_resource_types.yaml
@@ -8,7 +8,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters:
     mode: "blacklist"
     resource_type_list:

--- a/samples/always_violates.yaml
+++ b/samples/always_violates.yaml
@@ -23,5 +23,5 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters: {}

--- a/samples/appengine_location.yaml
+++ b/samples/appengine_location.yaml
@@ -8,7 +8,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters:
     locations:
     - "australia*"

--- a/samples/appengine_versions.yaml
+++ b/samples/appengine_versions.yaml
@@ -23,5 +23,5 @@ metadata:
 spec:
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters: {}

--- a/samples/bigquery_cmek.yaml
+++ b/samples/bigquery_cmek.yaml
@@ -8,5 +8,5 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters: {}

--- a/samples/bigquery_table_retention.yaml
+++ b/samples/bigquery_table_retention.yaml
@@ -22,7 +22,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters:
     minimum_retention_days: 100
     maximum_retention_days: 200

--- a/samples/cmek_rotation.yaml
+++ b/samples/cmek_rotation.yaml
@@ -25,7 +25,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters:
     # Optionaly specify the required key rotation period.  Default is 365 days
     # Valid time units are  "ns", "us", "ms", "s", "m", "h"

--- a/samples/cmek_rotation_100_days.yaml
+++ b/samples/cmek_rotation_100_days.yaml
@@ -24,7 +24,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters:
     # Optionaly specify the required key rotation period.  Default is 365 days
     # Valid time units are  "ns", "us", "ms", "s", "m", "h"

--- a/samples/cmek_settings.yaml
+++ b/samples/cmek_settings.yaml
@@ -23,7 +23,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters:
     # Optionaly specify the required key rotation period.  Default is 365 days
     # Valid time units are  "ns", "us", "ms", "s", "m", "h"

--- a/samples/compute_network_interface_whitelist.yaml
+++ b/samples/compute_network_interface_whitelist.yaml
@@ -23,7 +23,7 @@ spec:
   match:
     gcp:
       target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-      - "organization/*"
+      - "organizations/**"
   parameters:
     whitelist:
     - https://www.googleapis.com/compute/v1/projects/vpc-sc-pub-sub-billing-alerts/global/networks/default1

--- a/samples/dataproc_location.yaml
+++ b/samples/dataproc_location.yaml
@@ -23,7 +23,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters:
     locations:
     - "asia*"

--- a/samples/enforce_label.yaml
+++ b/samples/enforce_label.yaml
@@ -23,7 +23,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters:
     # required parameter: list of label objects that resources should have.
     # A label object is composed of a key value pair like: 

--- a/samples/gke_allowed_node_sa_scope.yaml
+++ b/samples/gke_allowed_node_sa_scope.yaml
@@ -24,7 +24,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   # By default, the scopes listed here is being used:
   # https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#reduce_node_sa_scopes
   parameters: {}

--- a/samples/gke_cluster_location.yaml
+++ b/samples/gke_cluster_location.yaml
@@ -22,7 +22,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters:
     mode: "allowlist"
     locations:

--- a/samples/gke_cluster_version.yaml
+++ b/samples/gke_cluster_version.yaml
@@ -22,7 +22,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters:
     mode: "allowlist"
     version_type: "master"

--- a/samples/gke_container_optimized_os.yaml
+++ b/samples/gke_container_optimized_os.yaml
@@ -26,5 +26,5 @@ spec:
   match:
     gcp:
       target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-      - "organization/*"
+      - "organizations/**"
   parameters: {}

--- a/samples/gke_dashboard_disable.yaml
+++ b/samples/gke_dashboard_disable.yaml
@@ -27,5 +27,5 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters: {}

--- a/samples/gke_disable_default_service_account.yaml
+++ b/samples/gke_disable_default_service_account.yaml
@@ -26,5 +26,5 @@ spec:
   match:
     gcp:
       target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-      - "organization/*"
+      - "organizations/**"
   parameters: {}

--- a/samples/gke_disable_legacy_endpoints.yaml
+++ b/samples/gke_disable_legacy_endpoints.yaml
@@ -26,5 +26,5 @@ spec:
   match:
     gcp:
       target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-      - "organization/*"
+      - "organizations/**"
   parameters: {}

--- a/samples/gke_enable_alias_ip_ranges.yaml
+++ b/samples/gke_enable_alias_ip_ranges.yaml
@@ -26,5 +26,5 @@ spec:
   match:
     gcp:
       target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-      - "organization/*"
+      - "organizations/**"
   parameters: {}

--- a/samples/gke_enable_logging.yaml
+++ b/samples/gke_enable_logging.yaml
@@ -22,7 +22,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters:
     mode: allowlist
     asset_types:

--- a/samples/gke_enable_shielded_nodes.yaml
+++ b/samples/gke_enable_shielded_nodes.yaml
@@ -23,5 +23,5 @@ spec:
   match:
     gcp:
       target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-      - "organization/*"
+      - "organizations/**"
   parameters: {}

--- a/samples/gke_enable_stackdriver_kubernetes_engine_monitoring.yaml
+++ b/samples/gke_enable_stackdriver_kubernetes_engine_monitoring.yaml
@@ -25,5 +25,5 @@ spec:
   match:
     gcp:
       target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-      - "organization/*"
+      - "organizations/**"
   parameters: {}

--- a/samples/gke_enable_stackdriver_logging.yaml
+++ b/samples/gke_enable_stackdriver_logging.yaml
@@ -25,5 +25,5 @@ spec:
   match:
     gcp:
       target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-      - "organization/*"
+      - "organizations/**"
   parameters: {}

--- a/samples/gke_enable_stackdriver_monitoring.yaml
+++ b/samples/gke_enable_stackdriver_monitoring.yaml
@@ -25,5 +25,5 @@ spec:
   match:
     gcp:
       target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-      - "organization/*"
+      - "organizations/**"
   parameters: {}

--- a/samples/gke_enable_workload_identity.yaml
+++ b/samples/gke_enable_workload_identity.yaml
@@ -23,5 +23,5 @@ spec:
   match:
     gcp:
       target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-      - "organization/*"
+      - "organizations/**"
   parameters: {}

--- a/samples/gke_legacy_abac.yaml
+++ b/samples/gke_legacy_abac.yaml
@@ -26,5 +26,5 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters: {}

--- a/samples/gke_node_pool_auto_upgrade.yaml
+++ b/samples/gke_node_pool_auto_upgrade.yaml
@@ -27,5 +27,5 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters: {}

--- a/samples/gke_restrict_pod_traffic.yaml
+++ b/samples/gke_restrict_pod_traffic.yaml
@@ -24,5 +24,5 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters: {}

--- a/samples/iam_allowed_roles.yaml
+++ b/samples/iam_allowed_roles.yaml
@@ -22,7 +22,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
     exclude: [] # optional, default is no exclusions
   parameters:
     mode: "allow"

--- a/samples/iam_banned_roles.yaml
+++ b/samples/iam_banned_roles.yaml
@@ -22,7 +22,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
     exclude: [] # optional, default is no exclusions
   parameters:
     mode: "ban"

--- a/samples/iam_block_service_account_creator_role.yaml
+++ b/samples/iam_block_service_account_creator_role.yaml
@@ -10,7 +10,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
     exclude: [] # optional, default is no exclusions
   parameters:
     mode: denylist

--- a/samples/iam_deny_public.yaml
+++ b/samples/iam_deny_public.yaml
@@ -9,7 +9,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
     exclude: [] # optional, default is no exclusions
   parameters:
     mode: denylist

--- a/samples/iam_deny_role.yaml
+++ b/samples/iam_deny_role.yaml
@@ -10,7 +10,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
     exclude: [] # optional, default is no exclusions
   parameters:
     mode: denylist

--- a/samples/iam_restrict_domain.yaml
+++ b/samples/iam_restrict_domain.yaml
@@ -23,7 +23,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
     exclude: []
   parameters:
     domains:

--- a/samples/iam_restrict_gmail.yaml
+++ b/samples/iam_restrict_gmail.yaml
@@ -24,7 +24,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
     exclude: []
   parameters:
     mode: denylist

--- a/samples/iam_restrict_gmail_bigquery_dataset.yaml
+++ b/samples/iam_restrict_gmail_bigquery_dataset.yaml
@@ -23,7 +23,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
     exclude: []
   parameters:
     mode: denylist

--- a/samples/iam_restrict_googlegroups_bigquery_dataset.yaml
+++ b/samples/iam_restrict_googlegroups_bigquery_dataset.yaml
@@ -23,7 +23,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
     exclude: []
   parameters:
     mode: denylist

--- a/samples/iam_restrict_role.yaml
+++ b/samples/iam_restrict_role.yaml
@@ -8,7 +8,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
     exclude: [] # optional, default is no exclusions
   parameters:
     mode: allowlist

--- a/samples/iam_service_accounts_only.yaml
+++ b/samples/iam_service_accounts_only.yaml
@@ -11,7 +11,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters:
     domains:
     - gserviceaccount.com

--- a/samples/legacy/gke_cluster_location.yaml
+++ b/samples/legacy/gke_cluster_location.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     allowed_locations:
         - us-central1

--- a/samples/legacy/vpc_sc_project_perimeter_v1_whitelist.yaml
+++ b/samples/legacy/vpc_sc_project_perimeter_v1_whitelist.yaml
@@ -20,7 +20,7 @@ spec:
   severity: high
   match:
     gcp:
-      target: ["organization/*"]
+      target: ["organizations/**"]
   parameters:
     mode: whitelist
     project_id: 179891054368

--- a/samples/network_enable_firewall_logs.yaml
+++ b/samples/network_enable_firewall_logs.yaml
@@ -23,5 +23,5 @@ spec:
   match:
     gcp:
       target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-      - "organization/*"
+      - "organizations/**"
   parameters: {}

--- a/samples/network_enable_flow_logs.yaml
+++ b/samples/network_enable_flow_logs.yaml
@@ -26,5 +26,5 @@ spec:
   match:
     gcp:
       target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-      - "organization/*"
+      - "organizations/**"
   parameters: {}

--- a/samples/network_enable_private_google_access.yaml
+++ b/samples/network_enable_private_google_access.yaml
@@ -26,5 +26,5 @@ spec:
   match:
     gcp:
       target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-      - "organization/*"
+      - "organizations/**"
   parameters: {}

--- a/samples/network_restrict_default.yaml
+++ b/samples/network_restrict_default.yaml
@@ -23,5 +23,5 @@ spec:
   match:
     gcp:
       target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-      - "organization/*"
+      - "organizations/**"
   parameters: {}

--- a/samples/network_routing.yaml
+++ b/samples/network_routing.yaml
@@ -8,5 +8,5 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters: {}

--- a/samples/restrict_fw_rules_generic.yaml
+++ b/samples/restrict_fw_rules_generic.yaml
@@ -24,7 +24,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters:
     rules:
     - direction: "INGRESS"

--- a/samples/restrict_fw_rules_rdp_world_open.yaml
+++ b/samples/restrict_fw_rules_rdp_world_open.yaml
@@ -26,7 +26,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters:
     rules:
     - direction: "INGRESS"

--- a/samples/restrict_fw_rules_ssh_world_open.yaml
+++ b/samples/restrict_fw_rules_ssh_world_open.yaml
@@ -26,7 +26,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters:
     rules:
     - direction: "INGRESS"

--- a/samples/restrict_fw_rules_world_open.yaml
+++ b/samples/restrict_fw_rules_world_open.yaml
@@ -26,7 +26,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters:
     rules:
     - direction: "INGRESS"

--- a/samples/restrict_fw_rules_world_open_tcp_udp_all_ports.yaml
+++ b/samples/restrict_fw_rules_world_open_tcp_udp_all_ports.yaml
@@ -25,7 +25,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters:
     rules:
     - direction: "INGRESS"

--- a/samples/serviceusage_allow_basic_apis.yaml
+++ b/samples/serviceusage_allow_basic_apis.yaml
@@ -8,7 +8,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
     exclude: []
   parameters:
     mode: allow

--- a/samples/serviceusage_deny_apis.yaml
+++ b/samples/serviceusage_deny_apis.yaml
@@ -8,7 +8,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
     exclude: []
   parameters:
     mode: deny

--- a/samples/spanner_location.yaml
+++ b/samples/spanner_location.yaml
@@ -8,7 +8,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters:
     locations:
     - "asia*"

--- a/samples/sql_backup.yaml
+++ b/samples/sql_backup.yaml
@@ -24,4 +24,4 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"

--- a/samples/sql_backup_with_exemptions.yaml
+++ b/samples/sql_backup_with_exemptions.yaml
@@ -24,7 +24,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters:
     exemptions:
     - //cloudsql.googleapis.com/projects/brunore-db-test/instances/mysqlv2-nomaintenance

--- a/samples/sql_location.yaml
+++ b/samples/sql_location.yaml
@@ -23,7 +23,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters:
     mode: "allowlist"
     locations:

--- a/samples/sql_maintenance_window.yaml
+++ b/samples/sql_maintenance_window.yaml
@@ -25,4 +25,4 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"

--- a/samples/sql_public_ip.yaml
+++ b/samples/sql_public_ip.yaml
@@ -25,5 +25,5 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
     exclude: [] # optional, default is no exclusions

--- a/samples/storage_blacklist_public.yaml
+++ b/samples/storage_blacklist_public.yaml
@@ -24,7 +24,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
     exclude: [] # optional, default is no exclusions
   parameters:
     exemptions: [] # optional, default is no exemptions

--- a/samples/storage_bucket_policy_only.yaml
+++ b/samples/storage_bucket_policy_only.yaml
@@ -25,5 +25,5 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters: {}

--- a/samples/storage_bucket_retention.yaml
+++ b/samples/storage_bucket_retention.yaml
@@ -20,7 +20,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters:
     minimum_retention_days: 10
     maximum_retention_days: 30

--- a/samples/storage_cmek_encryption.yaml
+++ b/samples/storage_cmek_encryption.yaml
@@ -23,5 +23,5 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters: {}

--- a/samples/storage_location.yaml
+++ b/samples/storage_location.yaml
@@ -23,7 +23,7 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
   parameters:
     mode: "allowlist"
     locations:

--- a/samples/storage_logging.yaml
+++ b/samples/storage_logging.yaml
@@ -8,6 +8,6 @@ spec:
   severity: high
   match:
     target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-    - "organization/*"
+    - "organizations/**"
     exclude: [] # optional, default is no exclusions
   parameters: {}

--- a/samples/vpc_sc_ensure_access_levels.yaml
+++ b/samples/vpc_sc_ensure_access_levels.yaml
@@ -24,7 +24,7 @@ spec:
   match:
     gcp:
       target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-      - "organization/*"
+      - "organizations/**"
   parameters:
     required_access_levels:
     - abcd

--- a/samples/vpc_sc_ensure_project.yaml
+++ b/samples/vpc_sc_ensure_project.yaml
@@ -24,7 +24,7 @@ spec:
   match:
     gcp:
       target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-      - "organization/*"
+      - "organizations/**"
   parameters:
     required_projects:
     - "179891054369"

--- a/samples/vpc_sc_ensure_services.yaml
+++ b/samples/vpc_sc_ensure_services.yaml
@@ -23,7 +23,7 @@ spec:
   match:
     gcp:
       target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-      - "organization/*"
+      - "organizations/**"
   parameters:
     required_services:
     - compute.googleapis.com

--- a/samples/vpc_sc_ip_range.yaml
+++ b/samples/vpc_sc_ip_range.yaml
@@ -23,6 +23,6 @@ spec:
   match:
     gcp:
       target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-      - "organization/*"
+      - "organizations/**"
   parameters:
     maximum_cidr_size: 16

--- a/samples/vpc_sc_project_perimeter_blacklist.yaml
+++ b/samples/vpc_sc_project_perimeter_blacklist.yaml
@@ -23,7 +23,7 @@ spec:
   match:
     gcp:
       target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-      - "organization/*"
+      - "organizations/**"
   parameters:
     mode: blacklist
     project_number: 179891054368

--- a/samples/vpc_sc_project_perimeter_v1_blacklist.yaml
+++ b/samples/vpc_sc_project_perimeter_v1_blacklist.yaml
@@ -23,7 +23,7 @@ spec:
   match:
     gcp:
       target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-      - "organization/*"
+      - "organizations/**"
   parameters:
     mode: blacklist
     project_id: 179891054368

--- a/samples/vpc_sc_project_perimeter_whitelist.yaml
+++ b/samples/vpc_sc_project_perimeter_whitelist.yaml
@@ -23,7 +23,7 @@ spec:
   match:
     gcp:
       target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-      - "organization/*"
+      - "organizations/**"
   parameters:
     mode: whitelist
     project_number: 179891054368

--- a/samples/vpc_sc_whitelist_regions.yaml
+++ b/samples/vpc_sc_whitelist_regions.yaml
@@ -24,7 +24,7 @@ spec:
   match:
     gcp:
       target: # {"$ref":"#/definitions/io.k8s.cli.setters.target"}
-      - "organization/*"
+      - "organizations/**"
   parameters:
     regions:
     - US

--- a/validator/test/fixtures/allowed_resource_types/constraints/basic/blacklist/data.yaml
+++ b/validator/test/fixtures/allowed_resource_types/constraints/basic/blacklist/data.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters: 
     mode: "blacklist"
     resource_type_list:

--- a/validator/test/fixtures/allowed_resource_types/constraints/basic/whitelist/data.yaml
+++ b/validator/test/fixtures/allowed_resource_types/constraints/basic/whitelist/data.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters: 
     mode: "whitelist"
     resource_type_list:

--- a/validator/test/fixtures/app_service_versions/constraints/custom_count/data.yaml
+++ b/validator/test/fixtures/app_service_versions/constraints/custom_count/data.yaml
@@ -18,6 +18,6 @@ metadata:
   name: service_versions
 spec:
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     max_versions: 1

--- a/validator/test/fixtures/app_service_versions/constraints/default_constraint/data.yaml
+++ b/validator/test/fixtures/app_service_versions/constraints/default_constraint/data.yaml
@@ -18,5 +18,5 @@ metadata:
   name: service_versions
 spec:
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters: {}

--- a/validator/test/fixtures/appengine_location/constraints/data.yaml
+++ b/validator/test/fixtures/appengine_location/constraints/data.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters: 
     locations:
       - "australia*"

--- a/validator/test/fixtures/bigquery_cmek/constraints/data.yaml
+++ b/validator/test/fixtures/bigquery_cmek/constraints/data.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters: {}
   

--- a/validator/test/fixtures/bigquery_table_retention/constraints/max_retention_only/data.yaml
+++ b/validator/test/fixtures/bigquery_table_retention/constraints/max_retention_only/data.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     maximum_retention_days: 60
     exemptions: []

--- a/validator/test/fixtures/bigquery_table_retention/constraints/max_retention_only_one_exemption/data.yaml
+++ b/validator/test/fixtures/bigquery_table_retention/constraints/max_retention_only_one_exemption/data.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     maximum_retention_days: 60
     exemptions:

--- a/validator/test/fixtures/bigquery_table_retention/constraints/min_max_retention/data.yaml
+++ b/validator/test/fixtures/bigquery_table_retention/constraints/min_max_retention/data.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     minimum_retention_days: 31
     maximum_retention_days: 60

--- a/validator/test/fixtures/bigquery_table_retention/constraints/min_max_retention_one_exemption/data.yaml
+++ b/validator/test/fixtures/bigquery_table_retention/constraints/min_max_retention_one_exemption/data.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     minimum_retention_days: 31
     maximum_retention_days: 60

--- a/validator/test/fixtures/bigquery_table_retention/constraints/min_retention_only/data.yaml
+++ b/validator/test/fixtures/bigquery_table_retention/constraints/min_retention_only/data.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     minimum_retention_days: 31
     exemptions: []

--- a/validator/test/fixtures/bigquery_table_retention/constraints/min_retention_only_one_exemption/data.yaml
+++ b/validator/test/fixtures/bigquery_table_retention/constraints/min_retention_only_one_exemption/data.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     minimum_retention_days: 31
     exemptions:

--- a/validator/test/fixtures/compute_network_interface_whitelist/constraints/whitelist/data.yaml
+++ b/validator/test/fixtures/compute_network_interface_whitelist/constraints/whitelist/data.yaml
@@ -20,7 +20,7 @@ spec:
   severity: high
   match:
     gcp:
-      target: ["organization/*"]
+      target: ["organizations/**"]
   parameters:
       whitelist:
           - https://www.googleapis.com/compute/v1/projects/vpc-sc-pub-sub-billing-alerts/global/networks/default1

--- a/validator/test/fixtures/dataproc_location/constraints/data.yaml
+++ b/validator/test/fixtures/dataproc_location/constraints/data.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters: 
     locations:
       - "asia*"

--- a/validator/test/fixtures/enforce_labels/constraints/data.yaml
+++ b/validator/test/fixtures/enforce_labels/constraints/data.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mandatory_labels:
       - "label1": "^label1-value$"

--- a/validator/test/fixtures/gke_container_optimized_os/constraints/gke_container_optimized_os/data.yaml
+++ b/validator/test/fixtures/gke_container_optimized_os/constraints/gke_container_optimized_os/data.yaml
@@ -24,5 +24,5 @@ spec:
   severity: high
   match:
     gcp:
-      target: ["organization/*"]
+      target: ["organizations/**"]
   parameters: {}

--- a/validator/test/fixtures/gke_container_optimized_os/constraints/gke_container_optimized_os_containerd/data.yaml
+++ b/validator/test/fixtures/gke_container_optimized_os/constraints/gke_container_optimized_os_containerd/data.yaml
@@ -24,7 +24,7 @@ spec:
   severity: high
   match:
     gcp:
-      target: ["organization/*"]
+      target: ["organizations/**"]
   parameters:
     cos_containerd_allowed: true
 

--- a/validator/test/fixtures/gke_disable_default_service_account/constraints/disable_gke_default_service_account/data.yaml
+++ b/validator/test/fixtures/gke_disable_default_service_account/constraints/disable_gke_default_service_account/data.yaml
@@ -24,5 +24,5 @@ spec:
   severity: high
   match:
     gcp:
-      target: ["organization/*"]
+      target: ["organizations/**"]
   parameters: {}

--- a/validator/test/fixtures/gke_disable_legacy_endpoints/constraints/disable_gke_legacy_endpoints/data.yaml
+++ b/validator/test/fixtures/gke_disable_legacy_endpoints/constraints/disable_gke_legacy_endpoints/data.yaml
@@ -22,5 +22,5 @@ spec:
   severity: high
   match:
     gcp:
-      target: ["organization/*"]
+      target: ["organizations/**"]
   parameters: {}

--- a/validator/test/fixtures/gke_enable_alias_ip_ranges/constraints/enable_alias_ip_ranges/data.yaml
+++ b/validator/test/fixtures/gke_enable_alias_ip_ranges/constraints/enable_alias_ip_ranges/data.yaml
@@ -20,5 +20,5 @@ spec:
   severity: high
   match:
     gcp:
-      target: ["organization/*"]
+      target: ["organizations/**"]
   parameters: {}

--- a/validator/test/fixtures/gke_enable_shielded_nodes/constraints/enable_shielded_nodes/data.yaml
+++ b/validator/test/fixtures/gke_enable_shielded_nodes/constraints/enable_shielded_nodes/data.yaml
@@ -20,5 +20,5 @@ spec:
   severity: high
   match:
     gcp:
-      target: ["organization/*"]
+      target: ["organizations/**"]
   parameters: {}

--- a/validator/test/fixtures/gke_enable_stackdriver_kubernetes_engine_monitoring/constraints/data.yaml
+++ b/validator/test/fixtures/gke_enable_stackdriver_kubernetes_engine_monitoring/constraints/data.yaml
@@ -24,5 +24,5 @@ spec:
   severity: high
   match:
     gcp:
-      target: ["organization/*"]
+      target: ["organizations/**"]
   parameters: {}

--- a/validator/test/fixtures/gke_enable_stackdriver_logging/constraints/enable_gke_stackdriver_logging/data.yaml
+++ b/validator/test/fixtures/gke_enable_stackdriver_logging/constraints/enable_gke_stackdriver_logging/data.yaml
@@ -22,5 +22,5 @@ spec:
   severity: high
   match:
     gcp:
-      target: ["organization/*"]
+      target: ["organizations/**"]
   parameters: {}

--- a/validator/test/fixtures/gke_enable_stackdriver_monitoring/constraints/enable_gke_stackdriver_monitoring/data.yaml
+++ b/validator/test/fixtures/gke_enable_stackdriver_monitoring/constraints/enable_gke_stackdriver_monitoring/data.yaml
@@ -20,5 +20,5 @@ spec:
   severity: high
   match:
     gcp:
-      target: ["organization/*"]
+      target: ["organizations/**"]
   parameters: {}

--- a/validator/test/fixtures/gke_enable_workload_identity/constraints/enable_gke_workload_identity/data.yaml
+++ b/validator/test/fixtures/gke_enable_workload_identity/constraints/enable_gke_workload_identity/data.yaml
@@ -22,5 +22,5 @@ spec:
   severity: high
   match:
     gcp:
-      target: ["organization/*"]
+      target: ["organizations/**"]
   parameters: {}

--- a/validator/test/fixtures/iam_allow_ban_roles/constraints/iam_allow_ban_roles_allow_all_roles_non_wildcard/data.yaml
+++ b/validator/test/fixtures/iam_allow_ban_roles/constraints/iam_allow_ban_roles_allow_all_roles_non_wildcard/data.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
     exclude: [] # optional, default is no exclusions
   parameters:
     mode: "allow"

--- a/validator/test/fixtures/iam_allow_ban_roles/constraints/iam_allow_ban_roles_allow_all_roles_wildcard/data.yaml
+++ b/validator/test/fixtures/iam_allow_ban_roles/constraints/iam_allow_ban_roles_allow_all_roles_wildcard/data.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
     exclude: [] # optional, default is no exclusions
   parameters:
     mode: "allow"

--- a/validator/test/fixtures/iam_allow_ban_roles/constraints/iam_allow_ban_roles_allow_one_role/data.yaml
+++ b/validator/test/fixtures/iam_allow_ban_roles/constraints/iam_allow_ban_roles_allow_one_role/data.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
     exclude: [] # optional, default is no exclusions
   parameters:
     mode: "allow"

--- a/validator/test/fixtures/iam_allow_ban_roles/constraints/iam_allow_ban_roles_ban_all_roles_non_wildcard/data.yaml
+++ b/validator/test/fixtures/iam_allow_ban_roles/constraints/iam_allow_ban_roles_ban_all_roles_non_wildcard/data.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
     exclude: [] # optional, default is no exclusions
   parameters:
     mode: "ban"

--- a/validator/test/fixtures/iam_allow_ban_roles/constraints/iam_allow_ban_roles_ban_all_roles_wildcard/data.yaml
+++ b/validator/test/fixtures/iam_allow_ban_roles/constraints/iam_allow_ban_roles_ban_all_roles_wildcard/data.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
     exclude: [] # optional, default is no exclusions
   parameters:
     mode: "ban"

--- a/validator/test/fixtures/iam_allow_ban_roles/constraints/iam_allow_ban_roles_ban_one_role/data.yaml
+++ b/validator/test/fixtures/iam_allow_ban_roles/constraints/iam_allow_ban_roles_ban_one_role/data.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
     exclude: [] # optional, default is no exclusions
   parameters:
     mode: "ban"

--- a/validator/test/fixtures/network_enable_firewall_logs/constraints/data.yaml
+++ b/validator/test/fixtures/network_enable_firewall_logs/constraints/data.yaml
@@ -22,5 +22,5 @@ spec:
   severity: high
   match:
     gcp:
-      target: ["organization/*"]
+      target: ["organizations/**"]
   parameters: {}

--- a/validator/test/fixtures/network_enable_flow_logs/constraints/data.yaml
+++ b/validator/test/fixtures/network_enable_flow_logs/constraints/data.yaml
@@ -24,5 +24,5 @@ spec:
   severity: high
   match:
     gcp:
-      target: ["organization/*"]
+      target: ["organizations/**"]
   parameters: {}

--- a/validator/test/fixtures/network_enable_private_google_access/constraints/data.yaml
+++ b/validator/test/fixtures/network_enable_private_google_access/constraints/data.yaml
@@ -24,5 +24,5 @@ spec:
   severity: high
   match:
     gcp:
-      target: ["organization/*"]
+      target: ["organizations/**"]
   parameters: {}

--- a/validator/test/fixtures/network_restrict_default/constraints/data.yaml
+++ b/validator/test/fixtures/network_restrict_default/constraints/data.yaml
@@ -22,5 +22,5 @@ spec:
   severity: high
   match:
     gcp:
-      target: ["organization/*"]
+      target: ["organizations/**"]
   parameters: {}

--- a/validator/test/fixtures/network_routing/constraints/data.yaml
+++ b/validator/test/fixtures/network_routing/constraints/data.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters: {}

--- a/validator/test/fixtures/resource_value_pattern/constraints/data.yaml
+++ b/validator/test/fixtures/resource_value_pattern/constraints/data.yaml
@@ -21,7 +21,7 @@ list:
       severity: high
       match:
         gcp:
-          target: ["organization/*"]
+          target: ["organizations/**"]
           exclude: [] # optional, default is no exclusions
       parameters:
         mode: allowlist
@@ -38,7 +38,7 @@ list:
       severity: high
       match:
         gcp:
-          target: ["organization/*"]
+          target: ["organizations/**"]
           exclude: [] # optional, default is no exclusions
       parameters:
         mode: allowlist
@@ -57,7 +57,7 @@ list:
       severity: high
       match:
         gcp:
-          target: ["organization/*"]
+          target: ["organizations/**"]
           exclude: [] # optional, default is no exclusions
       parameters:
         mode: allowlist
@@ -73,7 +73,7 @@ list:
       severity: high
       match:
         gcp:
-          target: ["organization/*"]
+          target: ["organizations/**"]
           exclude: [] # optional, default is no exclusions
       parameters:
         mode: denylist
@@ -90,7 +90,7 @@ list:
       severity: high
       match:
         gcp:
-          target: ["organization/*"]
+          target: ["organizations/**"]
           exclude: [] # optional, default is no exclusions
       parameters:
         mode: denylist
@@ -109,7 +109,7 @@ list:
       severity: high
       match:
         gcp:
-          target: ["organization/*"]
+          target: ["organizations/**"]
           exclude: [] # optional, default is no exclusions
       parameters:
         mode: denylist

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/all/allowlist/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/all/allowlist/data.yaml
@@ -21,7 +21,7 @@ eetadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mode: "allowlist"
     rules:

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/all/denylist/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/all/denylist/data.yaml
@@ -21,7 +21,7 @@ eetadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mode: "denylist"
     rules:

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/exemption/exact/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/exemption/exact/data.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mode: "allowlist"
     rules:

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/exemption/regex/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/exemption/regex/data.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mode: "allowlist"
     rules:

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/exemption/unset/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/exemption/unset/data.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mode: "allowlist"
     rules:

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/misc/advanced/allowlist/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/misc/advanced/allowlist/data.yaml
@@ -21,7 +21,7 @@ eetadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mode: "allowlist"
     rules:

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/misc/advanced/denylist/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/misc/advanced/denylist/data.yaml
@@ -21,7 +21,7 @@ eetadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mode: "denylist"
     rules:

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/misc/basic/allowlist/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/misc/basic/allowlist/data.yaml
@@ -21,7 +21,7 @@ eetadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mode: "allowlist"
     rules:

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/misc/basic/denylist/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/misc/basic/denylist/data.yaml
@@ -21,7 +21,7 @@ eetadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mode: "denylist"
     rules:

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/protocol_and_all_ports/allowlist/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/protocol_and_all_ports/allowlist/data.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mode: "allowlist"
     rules:

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/protocol_and_all_ports/denylist/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/protocol_and_all_ports/denylist/data.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mode: "denylist"
     rules:

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/protocol_and_port/advanced/allowlist/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/protocol_and_port/advanced/allowlist/data.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mode: "allowlist"
     rules:

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/protocol_and_port/advanced/denylist/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/protocol_and_port/advanced/denylist/data.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mode: "denylist"
     rules:

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/protocol_and_port/basic/allowlist/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/protocol_and_port/basic/allowlist/data.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mode: "allowlist"
     rules:

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/protocol_and_port/basic/denylist/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/protocol_and_port/basic/denylist/data.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mode: "denylist"
     rules:

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/sources/advanced/allowlist/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/sources/advanced/allowlist/data.yaml
@@ -21,7 +21,7 @@ eetadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mode: "allowlist"
     rules:

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/sources/advanced/denylist/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/sources/advanced/denylist/data.yaml
@@ -21,7 +21,7 @@ eetadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mode: "denylist"
     rules:

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/sources/basic/allowlist/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/sources/basic/allowlist/data.yaml
@@ -21,7 +21,7 @@ eetadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mode: "allowlist"
     rules:

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/sources/basic/denylist/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/sources/basic/denylist/data.yaml
@@ -21,7 +21,7 @@ eetadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mode: "denylist"
     rules:

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/targets/advanced/allowlist/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/targets/advanced/allowlist/data.yaml
@@ -21,7 +21,7 @@ eetadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mode: "allowlist"
     rules:

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/targets/advanced/denylist/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/targets/advanced/denylist/data.yaml
@@ -21,7 +21,7 @@ eetadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mode: "denylist"
     rules:

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/targets/basic/allowlist/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/targets/basic/allowlist/data.yaml
@@ -21,7 +21,7 @@ eetadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mode: "allowlist"
     rules:

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/targets/basic/denylist/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/targets/basic/denylist/data.yaml
@@ -21,7 +21,7 @@ eetadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     mode: "denylist"
     rules:

--- a/validator/test/fixtures/spanner_location/constraints/data.yaml
+++ b/validator/test/fixtures/spanner_location/constraints/data.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters: 
     locations:
       - "asia*"

--- a/validator/test/fixtures/sql_backup/constraints/exemption/data.yaml
+++ b/validator/test/fixtures/sql_backup/constraints/exemption/data.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     exemptions:
       - //cloudsql.googleapis.com/projects/brunore-db-test/instances/mysqlv2-nomaintenance

--- a/validator/test/fixtures/sql_backup/constraints/no_parameter/data.yaml
+++ b/validator/test/fixtures/sql_backup/constraints/no_parameter/data.yaml
@@ -21,5 +21,5 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
     

--- a/validator/test/fixtures/sql_maintenance_window/constraints/exemption/data.yaml
+++ b/validator/test/fixtures/sql_maintenance_window/constraints/exemption/data.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     hours: []
     exemptions:

--- a/validator/test/fixtures/sql_maintenance_window/constraints/no_hour/data.yaml
+++ b/validator/test/fixtures/sql_maintenance_window/constraints/no_hour/data.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     hours: []
     exemptions: []

--- a/validator/test/fixtures/sql_maintenance_window/constraints/no_parameter/data.yaml
+++ b/validator/test/fixtures/sql_maintenance_window/constraints/no_parameter/data.yaml
@@ -21,5 +21,5 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
     

--- a/validator/test/fixtures/sql_maintenance_window/constraints/specific_hours/data.yaml
+++ b/validator/test/fixtures/sql_maintenance_window/constraints/specific_hours/data.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     hours: # UTC time, 
       - 20

--- a/validator/test/fixtures/sql_public_ip/constraints/data.yaml
+++ b/validator/test/fixtures/sql_public_ip/constraints/data.yaml
@@ -21,4 +21,4 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]

--- a/validator/test/fixtures/storage_bucket_retention/constraints/max_retention_only/data.yaml
+++ b/validator/test/fixtures/storage_bucket_retention/constraints/max_retention_only/data.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     maximum_retention_days: 60
     exemptions: []

--- a/validator/test/fixtures/storage_bucket_retention/constraints/max_retention_only_one_exemption/data.yaml
+++ b/validator/test/fixtures/storage_bucket_retention/constraints/max_retention_only_one_exemption/data.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     maximum_retention_days: 60
     exemptions:

--- a/validator/test/fixtures/storage_bucket_retention/constraints/min_max_retention/data.yaml
+++ b/validator/test/fixtures/storage_bucket_retention/constraints/min_max_retention/data.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     minimum_retention_days: 25
     maximum_retention_days: 60

--- a/validator/test/fixtures/storage_bucket_retention/constraints/min_max_retention_one_exemption/data.yaml
+++ b/validator/test/fixtures/storage_bucket_retention/constraints/min_max_retention_one_exemption/data.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     minimum_retention_days: 110
     maximum_retention_days: 200

--- a/validator/test/fixtures/storage_bucket_retention/constraints/min_retention_only/data.yaml
+++ b/validator/test/fixtures/storage_bucket_retention/constraints/min_retention_only/data.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     minimum_retention_days: 25
     exemptions: []

--- a/validator/test/fixtures/storage_bucket_retention/constraints/min_retention_only_one_exemption/data.yaml
+++ b/validator/test/fixtures/storage_bucket_retention/constraints/min_retention_only_one_exemption/data.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organization/*"]
+    target: ["organizations/**"]
   parameters:
     minimum_retention_days: 110
     exemptions:

--- a/validator/test/fixtures/vpc_sc_ensure_access_levels/constraints/data.yaml
+++ b/validator/test/fixtures/vpc_sc_ensure_access_levels/constraints/data.yaml
@@ -20,7 +20,7 @@ spec:
   severity: high
   match:
     gcp:
-      target: ["organization/*"]
+      target: ["organizations/**"]
   parameters:
       required_access_levels:
           - abcd

--- a/validator/test/fixtures/vpc_sc_ensure_project/constraints/data.yaml
+++ b/validator/test/fixtures/vpc_sc_ensure_project/constraints/data.yaml
@@ -20,7 +20,7 @@ spec:
   severity: high
   match:
     gcp:
-      target: ["organization/*"]
+      target: ["organizations/**"]
   parameters:
       required_projects:
         - "179891054369"

--- a/validator/test/fixtures/vpc_sc_ensure_services/constraints/data.yaml
+++ b/validator/test/fixtures/vpc_sc_ensure_services/constraints/data.yaml
@@ -20,7 +20,7 @@ spec:
   severity: high
   match:
     gcp:
-      target: ["organization/*"]
+      target: ["organizations/**"]
   parameters:
       required_services:
         - compute.googleapis.com

--- a/validator/test/fixtures/vpc_sc_ip_range/constraints/data.yaml
+++ b/validator/test/fixtures/vpc_sc_ip_range/constraints/data.yaml
@@ -20,6 +20,6 @@ spec:
   severity: high
   match:
     gcp:
-      target: ["organization/*"]
+      target: ["organizations/**"]
   parameters:
       maximum_cidr_size: 16

--- a/validator/test/fixtures/vpc_sc_project_perimeter/constraints/blacklist/data.yaml
+++ b/validator/test/fixtures/vpc_sc_project_perimeter/constraints/blacklist/data.yaml
@@ -20,7 +20,7 @@ spec:
   severity: high
   match:
     gcp:
-      target: ["organization/*"]
+      target: ["organizations/**"]
   parameters:
     mode: blacklist
     project_id: 179891054368

--- a/validator/test/fixtures/vpc_sc_project_perimeter/constraints/whitelist/data.yaml
+++ b/validator/test/fixtures/vpc_sc_project_perimeter/constraints/whitelist/data.yaml
@@ -20,7 +20,7 @@ spec:
   severity: high
   match:
     gcp:
-      target: ["organization/*"]
+      target: ["organizations/**"]
   parameters:
     mode: whitelist
     project_id: 179891054368

--- a/validator/test/fixtures/vpc_sc_project_perimeter_v2/constraints/blacklist/data.yaml
+++ b/validator/test/fixtures/vpc_sc_project_perimeter_v2/constraints/blacklist/data.yaml
@@ -20,7 +20,7 @@ spec:
   severity: high
   match:
     gcp:
-      target: ["organization/*"]
+      target: ["organizations/**"]
   parameters:
     mode: blacklist
     project_number: 179891054368

--- a/validator/test/fixtures/vpc_sc_project_perimeter_v2/constraints/whitelist/data.yaml
+++ b/validator/test/fixtures/vpc_sc_project_perimeter_v2/constraints/whitelist/data.yaml
@@ -20,7 +20,7 @@ spec:
   severity: high
   match:
     gcp:
-      target: ["organization/*"]
+      target: ["organizations/**"]
   parameters:
     mode: whitelist
     project_number: 179891054368

--- a/validator/test/fixtures/vpc_sc_whitelist_regions/constraints/data.yaml
+++ b/validator/test/fixtures/vpc_sc_whitelist_regions/constraints/data.yaml
@@ -20,7 +20,7 @@ spec:
   severity: high
   match:
     gcp:
-      target: ["organization/*"]
+      target: ["organizations/**"]
   parameters:
     regions:
       - US


### PR DESCRIPTION
FCV now takes plural target format (eg, organizations, projects, folders) to
align with the GCP API types.  Legacy behavior is still allowed for v1alpha1
types (eg, * will still match like ** and project will match projects).

Fixes https://github.com/forseti-security/config-validator/issues/74