### PR TITLE
minor fix in iam audit log tests

### DIFF
--- a/policies/templates/gcp_iam_audit_log.yaml
+++ b/policies/templates/gcp_iam_audit_log.yaml
@@ -28,14 +28,14 @@ spec:
         openAPIV3Schema:
           properties:
             services:
-              description: "The services that should have audit logging enabled. 
+              description: "The services that should have audit logging enabled.
                 Example: 'storage.googleapis.com' for Cloud Storage.
                 'allServices' is a special value that covers all services"
               type: array
               items:
                 type: string
             log_types:
-              description: "The log types that should be enabled. 
+              description: "The log types that should be enabled.
                 Valid values are ADMIN_READ, DATA_WRITE, and DATA_READ."
               type: array
               items:

--- a/validator/iam_audit_log_test.rego
+++ b/validator/iam_audit_log_test.rego
@@ -15,7 +15,7 @@ test_audit_log_skip_good_project {
 }
 
 test_audit_log_skip_irrelevant_asset_type {
-	not resources_in_violation["//cloudresourcemanager.googleapis.com/ignore-asset-type"]
+	not resources_in_violation["//cloudresourcemanager.googleapis.com/projects/ignore-asset-type"]
 }
 
 test_audit_log_missing_service {

--- a/validator/iam_audit_log_test.rego
+++ b/validator/iam_audit_log_test.rego
@@ -15,7 +15,7 @@ test_audit_log_skip_good_project {
 }
 
 test_audit_log_skip_irrelevant_asset_type {
-	not resources_in_violation["//cloudresourcemanager.googleapis.com/projects/ignore-asset-type"]
+	not resources_in_violation["//cloudresourcemanager.googleapis.com/ignore-asset-type"]
 }
 
 test_audit_log_missing_service {

--- a/validator/test/fixtures/iam_audit_log/assets/data.json
+++ b/validator/test/fixtures/iam_audit_log/assets/data.json
@@ -97,7 +97,7 @@
         }
     },
     {
-        "name": "//cloudresourcemanager.googleapis.com/ignore-asset-type",
+        "name": "//cloudresourcemanager.googleapis.com/projects/ignore-asset-type",
         "asset_type": "storage.googleapis.com/Bucket",
         "iam_policy": {
             "version": 1,


### PR DESCRIPTION
The name of the resource in the `data.json` is `//cloudresourcemanager.googleapis.com/ignore-asset-type`