### PR TITLE
fix kpt bundle param

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Download the full policy library and install the [Forseti bundle](./docs/bundles
 export BUNDLE=forseti-security
 kpt pkg get https://github.com/forseti-security/policy-library.git ./policy-library
 kpt fn source policy-library/samples/ | \
-  kpt fn run --image gcr.io/config-validator/get-policy-bundle:latest -- bundle=bundles.validator.forsetisecurity.org/$BUNDLE | \
+  kpt fn run --image gcr.io/config-validator/get-policy-bundle:latest -- bundle=$BUNDLE | \
   kpt fn sink policy-library/policies/constraints/
 ```
 


### PR DESCRIPTION
Current instruction to create Forseti bundle 

```
export BUNDLE=forseti-security
kpt pkg get https://github.com/forseti-security/policy-library.git ./policy-library
kpt fn source policy-library/samples/ | \
  kpt fn run --image gcr.io/config-validator/get-policy-bundle:latest -- bundle=bundles.validator.forsetisecurity.org/$BUNDLE | \
  kpt fn sink policy-library/policies/constraints/
```

fails with error:

```
Error: bundle does not exist: bundles.validator.forsetisecurity.org/bundles.validator.forsetisecurity.org/forseti-security.
    at /home/node/app/dist/get_policy_bundle.js:39:19
    at Generator.next (<anonymous>)
    at /home/node/app/dist/get_policy_bundle.js:23:71
    at new Promise (<anonymous>)
    at __awaiter (/home/node/app/dist/get_policy_bundle.js:19:12)
    at getPolicyBundle (/home/node/app/dist/get_policy_bundle.js:30:12)
    at runFn (/home/node/app/node_modules/kpt-functions/dist/src/run.js:132:11)
    at process._tickCallback (internal/process/next_tick.js:68:7)
Error: exit status 2
```

bundle param must be changed from: 

```
bundle=bundles.validator.forsetisecurity.org/$BUNDLE
```

to

```
bundle=$BUNDLE
```

to fix this issue