### PR TITLE
Add check for uniform bucket access level

### DIFF
--- a/policies/templates/gcp_storage_bucket_policy_only_v1.yaml
+++ b/policies/templates/gcp_storage_bucket_policy_only_v1.yaml
@@ -65,7 +65,7 @@ spec:
            	asset.asset_type == "storage.googleapis.com/Bucket"
            
            	bucket := asset.resource.data
-           	bucket_policy_enabled(bucket) != true
+           	bucket_policy_enabled(bucket) != true; uniform_bucket_level_access_enabled(bucket) != true
            
            	message := sprintf("%v does not have bucket policy only enabled.", [asset.name])
            	metadata := {"resource": asset.name}
@@ -78,5 +78,11 @@ spec:
            	iam_configuration := lib.get_default(bucket, "iamConfiguration", {})
            	bucket_policy_only := lib.get_default(iam_configuration, "bucketPolicyOnly", {})
            	bucket_policy_enabled := lib.get_default(bucket_policy_only, "enabled", null)
+           }
+
+           uniform_bucket_level_access_enabled(bucket) = uniform_bucket_level_access_enabled {
+          	iam_configuration := lib.get_default(bucket, "iamConfiguration", {})
+          	uniform_bucket_level_access := lib.get_default(iam_configuration, "uniformBucketLevelAccess", {})
+          	uniform_bucket_level_access_enabled := lib.get_default(uniform_bucket_level_access, "enabled", null)
            }
            #ENDINLINE

--- a/policies/templates/gcp_storage_bucket_policy_only_v1.yaml
+++ b/policies/templates/gcp_storage_bucket_policy_only_v1.yaml
@@ -81,8 +81,8 @@ spec:
            }
 
            uniform_bucket_level_access_enabled(bucket) = uniform_bucket_level_access_enabled {
-          	iam_configuration := lib.get_default(bucket, "iamConfiguration", {})
-          	uniform_bucket_level_access := lib.get_default(iam_configuration, "uniformBucketLevelAccess", {})
-          	uniform_bucket_level_access_enabled := lib.get_default(uniform_bucket_level_access, "enabled", null)
+           	iam_configuration := lib.get_default(bucket, "iamConfiguration", {})
+           	uniform_bucket_level_access := lib.get_default(iam_configuration, "uniformBucketLevelAccess", {})
+           	uniform_bucket_level_access_enabled := lib.get_default(uniform_bucket_level_access, "enabled", null)
            }
            #ENDINLINE

--- a/policies/templates/gcp_storage_bucket_policy_only_v1.yaml
+++ b/policies/templates/gcp_storage_bucket_policy_only_v1.yaml
@@ -65,7 +65,8 @@ spec:
            	asset.asset_type == "storage.googleapis.com/Bucket"
            
            	bucket := asset.resource.data
-           	bucket_policy_enabled(bucket) != true; uniform_bucket_level_access_enabled(bucket) != true
+           	bucket_policy_enabled(bucket) != true
+           	uniform_bucket_level_access_enabled(bucket) != true
            
            	message := sprintf("%v does not have bucket policy only enabled.", [asset.name])
            	metadata := {"resource": asset.name}
@@ -79,7 +80,7 @@ spec:
            	bucket_policy_only := lib.get_default(iam_configuration, "bucketPolicyOnly", {})
            	bucket_policy_enabled := lib.get_default(bucket_policy_only, "enabled", null)
            }
-
+           
            uniform_bucket_level_access_enabled(bucket) = uniform_bucket_level_access_enabled {
            	iam_configuration := lib.get_default(bucket, "iamConfiguration", {})
            	uniform_bucket_level_access := lib.get_default(iam_configuration, "uniformBucketLevelAccess", {})

--- a/validator/storage_bucket_policy_only.rego
+++ b/validator/storage_bucket_policy_only.rego
@@ -27,7 +27,7 @@ deny[{
 	asset.asset_type == "storage.googleapis.com/Bucket"
 
 	bucket := asset.resource.data
-	bucket_policy_enabled(bucket) != true
+	bucket_policy_enabled(bucket) != true; uniform_bucket_level_access_enabled(bucket) != true
 
 	message := sprintf("%v does not have bucket policy only enabled.", [asset.name])
 	metadata := {"resource": asset.name}
@@ -40,4 +40,10 @@ bucket_policy_enabled(bucket) = bucket_policy_enabled {
 	iam_configuration := lib.get_default(bucket, "iamConfiguration", {})
 	bucket_policy_only := lib.get_default(iam_configuration, "bucketPolicyOnly", {})
 	bucket_policy_enabled := lib.get_default(bucket_policy_only, "enabled", null)
+}
+
+uniform_bucket_level_access_enabled(bucket) = uniform_bucket_level_access_enabled {
+	iam_configuration := lib.get_default(bucket, "iamConfiguration", {})
+	uniform_bucket_level_access := lib.get_default(iam_configuration, "uniformBucketLevelAccess", {})
+	uniform_bucket_level_access_enabled := lib.get_default(uniform_bucket_level_access, "enabled", null)
 }

--- a/validator/storage_bucket_policy_only.rego
+++ b/validator/storage_bucket_policy_only.rego
@@ -27,7 +27,8 @@ deny[{
 	asset.asset_type == "storage.googleapis.com/Bucket"
 
 	bucket := asset.resource.data
-	bucket_policy_enabled(bucket) != true; uniform_bucket_level_access_enabled(bucket) != true
+	bucket_policy_enabled(bucket) != true
+	uniform_bucket_level_access_enabled(bucket) != true
 
 	message := sprintf("%v does not have bucket policy only enabled.", [asset.name])
 	metadata := {"resource": asset.name}

--- a/validator/storage_bucket_policy_only_test.rego
+++ b/validator/storage_bucket_policy_only_test.rego
@@ -29,6 +29,10 @@ test_storage_bucket_policy_only_enabled {
 	not resources_in_violation["//storage.googleapis.com/my-storage-bucket-with-bucketpolicyonly"]
 }
 
+test_storage_uniform_bucket_level_access_enabled {
+	not resources_in_violation["//storage.googleapis.com/my-storage-bucketwithuniformbucketlevelaccess"]
+}
+
 test_storage_bucket_policy_only_violations_no_data {
 	resources_in_violation["//storage.googleapis.com/my-storage-bucket-with-no-bucketpolicyonly-data"]
 }

--- a/validator/test/fixtures/storage_bucket_policy_only/assets/data.json
+++ b/validator/test/fixtures/storage_bucket_policy_only/assets/data.json
@@ -44,6 +44,51 @@
   }
 },
 {
+  "name": "//storage.googleapis.com/my-storage-bucketwithuniformbucketlevelaccess",
+  "asset_type": "storage.googleapis.com/Bucket",
+  "resource": {
+    "version": "v1",
+    "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/storage/v1/rest",
+    "discovery_name": "Bucket",
+    "parent": "//cloudresourcemanager.googleapis.com/projects/68478495408",
+    "data": {
+      "acl": [],
+      "billing": {},
+      "cors": [],
+      "defaultObjectAcl": [],
+      "encryption": {
+        "defaultKmsKeyName": "projects/andresolarte-gke-ent/locations/us/keyRings/us-ring/cryptoKeys/key1"
+      },
+      "etag": "CAI=",
+      "iamConfiguration": {
+        "uniformBucketLevelAccess": {
+          "enabled": true,
+          "lockedTime": "2019-09-05T10:18:44.437Z"
+        }
+      },
+      "id": "my-storage-bucketwithuniformbucketlevelaccess",
+      "kind": "storage#bucket",
+      "labels": {},
+      "lifecycle": {
+        "rule": []
+      },
+      "location": "US-CENTRAL1",
+      "logging": {},
+      "metageneration": 2,
+      "name": "my-storage-bucketwithuniformbucketlevelaccess",
+      "owner": {},
+      "projectNumber": 68478495408,
+      "retentionPolicy": {},
+      "selfLink": "https://www.googleapis.com/storage/v1/b/my-storage-bucketwithuniformbucketlevelaccess",
+      "storageClass": "STANDARD",
+      "timeCreated": "2018-07-23T17:30:22.691Z",
+      "updated": "2019-09-05T10:18:44.437Z",
+      "versioning": {},
+      "website": {}
+    }
+  }
+},
+{
   "name": "//storage.googleapis.com/my-storage-bucket-with-null-bucketpolicyonly",
   "asset_type": "storage.googleapis.com/Bucket",
   "resource": {


### PR DESCRIPTION
This pull requests updates `validator/storage_bucket_policy_only.rego` and derived/related files to consider the `uniformBucketLevelAccess` property in addition of the deprecated `bucketPolicyOnly`.


Closes #388 
