### PR TITLE
fix user_guide sample command

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -377,7 +377,7 @@ session open, the next step is to copy over the sample IAM domain restriction
 constraint:
 
 ```
-cp policy-library/samples/iam_service_accounts_only.yaml policy-library/policies/constraints
+cp samples/iam_service_accounts_only.yaml policies/constraints
 ```
 
 Let's take a look at this constraint:


### PR DESCRIPTION
The command in the sample Cloud Shell is incorrect and I fixed it.


This [Cloud Shell's](https://console.cloud.google.com/cloudshell/open?cloudshell_image=gcr.io/graphite-cloud-shell-images/terraform:latest&cloudshell_git_repo=https://github.com/forseti-security/policy-library.git) current path is already in the policy-library repository.
```
$ pwd
/home/yuto_komai/cloudshell_open/policy-library
$ 
$ cp policy-library/samples/iam_service_accounts_only.yaml policy-library/policies/constraints
cp: cannot stat 'policy-library/samples/iam_service_accounts_only.yaml': No such file or directory
```

if fixed it
```
$ cp samples/iam_service_accounts_only.yaml policies/constraints 
$ 
$ ls -la policies/constraints
total 20
drwxr-xr-x 2 yuto_komai yuto_komai 4096 Feb 10 06:59 .
drwxr-xr-x 4 yuto_komai yuto_komai 4096 Feb 10 06:57 ..
-rw-r--r-- 1 yuto_komai yuto_komai  531 Feb 10 06:59 iam_service_accounts_only.yaml
-rw-r--r-- 1 yuto_komai yuto_komai  473 Feb 10 06:57 Kptfile
-rw-r--r-- 1 yuto_komai yuto_komai  193 Feb 10 06:57 README.md
```
