### PR TITLE
Opa v0.24.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ help: ## Prints help for targets with comments
 
 # Cloudbuild doesn't allow us to use the Dockerfile "ARG" feature so we have to
 # template the dockerfile, expand for each version then build.
-REGO_VERSIONS := v0.15.0 v0.16.0 v0.17.0
+REGO_VERSIONS := v0.15.0 v0.16.0 v0.24.0
 CI_IMAGES := $(foreach v,$(REGO_VERSIONS),ci-image-$v)
 .PHONY: ci-images
 ci-images: $(CI_IMAGES)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,10 +5,9 @@ steps:
 - name: 'gcr.io/config-validator/rego-v0.16.0'
   args: ['test']
   waitFor: ['-']
-# 0.17.0 has some errors on the library, this needs more investigation before we migrate.
-#- name: 'gcr.io/config-validator/rego-v0.17.0'
-#  args: ['test']
-#  waitFor: ['-']
+- name: 'gcr.io/config-validator/rego-v0.24.0'
+  args: ['test']
+  waitFor: ['-']
 - name: 'gcr.io/config-validator/rego-v0.15.0'
   args: ['check_sample_files']
   waitFor: ['-']


### PR DESCRIPTION
Replace rego v0.17.0 tests with v0.24.0. 
Lines up with https://github.com/forseti-security/config-validator/pull/162