### PR TITLE
Updated docs to reflect TFV semver releases

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -258,26 +258,29 @@ spec:
 ### Install Terraform Validator
 
 The released binaries are available under the `gs://terraform-validator` Google
-Cloud Storage bucket for Linux, Windows, and Mac. They are organized by release
-date, for example:
+Cloud Storage bucket for Linux, Windows, and Mac. They are organized by release,
+for example:
 
 ```
-$ gsutil ls -r gs://terraform-validator/releases
+$ gsutil ls -r "gs://terraform-validator/releases/v*"
 ...
-gs://terraform-validator/releases/2019-04-04/terraform-validator-darwin-amd64
-gs://terraform-validator/releases/2019-04-04/terraform-validator-linux-amd64
-gs://terraform-validator/releases/2019-04-04/terraform-validator-windows-amd64
+gs://terraform-validator/releases/v0.1.0/:
+gs://terraform-validator/releases/v0.1.0/terraform-validator-darwin-amd64
+gs://terraform-validator/releases/v0.1.0/terraform-validator-linux-amd64
+gs://terraform-validator/releases/v0.1.0/terraform-validator-windows-amd64
 ```
 
 To download the binary, you need to
 [install](https://cloud.google.com/storage/docs/gsutil_install#install) the
 `gsutil` tool first. The following command downloads the Linux version of
-Terraform Validator from YYYY-MM-DD release to your local directory:
+Terraform Validator from vX.X.X release to your local directory:
 
 ```
-gsutil cp gs://terraform-validator/releases/YYYY-MM-DD/terraform-validator-linux-amd64 .
+gsutil cp gs://terraform-validator/releases/vX.X.X/terraform-validator-linux-amd64 .
 chmod 755 terraform-validator-linux-amd64
 ```
+
+The full list of releases, with release notes, is available [on Github](https://github.com/GoogleCloudPlatform/terraform-validator/releases).
 
 ### For local development environments
 
@@ -440,7 +443,7 @@ Since your email address is in the IAM policy binding, the plan should result in
 a violation. Let's try this out:
 
 ```
-gsutil cp gs://terraform-validator/releases/2019-03-28/terraform-validator-linux-amd64 .
+gsutil cp gs://terraform-validator/releases/v0.1.0/terraform-validator-linux-amd64 .
 chmod 755 terraform-validator-linux-amd64
 ./terraform-validator-linux-amd64 validate tfplan.json --policy-path=policy-library
 ```


### PR DESCRIPTION
Terraform Validator is now using semver release versions. This change updates the docs to reflect that change, and to direct users to use the semver releases.