### PR TITLE
Removed references to Config Validator as a part of Forseti

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ You can easily set up a new (local) policy library by downloading a [bundle](./d
 Download the full policy library and install the [Forseti bundle](./docs/bundles/forseti-security.md):
 ```
 export BUNDLE=forseti-security
-kpt pkg get https://github.com/forseti-security/policy-library.git ./policy-library
+kpt pkg get https://github.com/GoogleCloudPlatform/policy-library.git ./policy-library
 kpt fn source policy-library/samples/ | \
   kpt fn run --image gcr.io/config-validator/get-policy-bundle:latest -- bundle=$BUNDLE | \
   kpt fn sink policy-library/policies/constraints/
 ```
 
-Once you have initialized a library, you might want to save it to [git](./docs/user_guide.md#https://github.com/forseti-security/policy-library/blob/master/docs/user_guide.md#get-started-with-the-policy-library-repository).
+Once you have initialized a library, you might want to save it to [git](./docs/user_guide.md#https://github.com/GoogleCloudPlatform/policy-library/blob/master/docs/user_guide.md#get-started-with-the-policy-library-repository).
 
 ## Developing a Constraint
 
@@ -59,10 +59,10 @@ Replaced:
 ```
 
 ### Linting Policies
-FCV provides a policy linter.  You can invoke it as:
+Config Validator provides a policy linter.  You can invoke it as:
 
 ```
-go get github.com/forseti-security/config-validator/cmd/policy-tool
+go get github.com/GoogleCloudPlatform/config-validator/cmd/policy-tool
 policy-tool --policies ./policies --policies ./samples --libs ./lib
 ```
 

--- a/bundler/dist/generate_docs.js
+++ b/bundler/dist/generate_docs.js
@@ -194,7 +194,7 @@ This bundle can be installed via kpt:
 
 \`\`\`
 export BUNDLE=${bundle.getName()}
-kpt pkg get https://github.com/forseti-security/policy-library.git ./policy-library
+kpt pkg get https://github.com/GoogleCloudPlatform/policy-library.git ./policy-library
 kpt fn source policy-library/samples/ | \\
   kpt fn run --image gcr.io/config-validator/get-policy-bundle:latest -- bundle=$BUNDLE | \\
   kpt fn sink policy-library/policies/constraints/

--- a/bundler/src/generate_docs.ts
+++ b/bundler/src/generate_docs.ts
@@ -205,7 +205,7 @@ This bundle can be installed via kpt:
 
 \`\`\`
 export BUNDLE=${bundle.getName()}
-kpt pkg get https://github.com/forseti-security/policy-library.git ./policy-library
+kpt pkg get https://github.com/GoogleCloudPlatform/policy-library.git ./policy-library
 kpt fn source policy-library/samples/ | \\
   kpt fn run --image gcr.io/config-validator/get-policy-bundle:latest -- bundle=$BUNDLE | \\
   kpt fn sink policy-library/policies/constraints/

--- a/docs/bundles/cis-v1.0.md
+++ b/docs/bundles/cis-v1.0.md
@@ -4,7 +4,7 @@ This bundle can be installed via kpt:
 
 ```
 export BUNDLE=cis-v1.0
-kpt pkg get https://github.com/forseti-security/policy-library.git ./policy-library
+kpt pkg get https://github.com/GoogleCloudPlatform/policy-library.git ./policy-library
 kpt fn source policy-library/samples/ | \
   kpt fn run --image gcr.io/config-validator/get-policy-bundle:latest -- bundle=$BUNDLE | \
   kpt fn sink policy-library/policies/constraints/

--- a/docs/bundles/cis-v1.1.md
+++ b/docs/bundles/cis-v1.1.md
@@ -4,7 +4,7 @@ This bundle can be installed via kpt:
 
 ```
 export BUNDLE=cis-v1.1
-kpt pkg get https://github.com/forseti-security/policy-library.git ./policy-library
+kpt pkg get https://github.com/GoogleCloudPlatform/policy-library.git ./policy-library
 kpt fn source policy-library/samples/ | \
   kpt fn run --image gcr.io/config-validator/get-policy-bundle:latest -- bundle=$BUNDLE | \
   kpt fn sink policy-library/policies/constraints/

--- a/docs/bundles/forseti-security.md
+++ b/docs/bundles/forseti-security.md
@@ -4,7 +4,7 @@ This bundle can be installed via kpt:
 
 ```
 export BUNDLE=forseti-security
-kpt pkg get https://github.com/forseti-security/policy-library.git ./policy-library
+kpt pkg get https://github.com/GoogleCloudPlatform/policy-library.git ./policy-library
 kpt fn source policy-library/samples/ | \
   kpt fn run --image gcr.io/config-validator/get-policy-bundle:latest -- bundle=$BUNDLE | \
   kpt fn sink policy-library/policies/constraints/

--- a/docs/bundles/gke-hardening-v2019.11.11.md
+++ b/docs/bundles/gke-hardening-v2019.11.11.md
@@ -4,7 +4,7 @@ This bundle can be installed via kpt:
 
 ```
 export BUNDLE=gke-hardening-v2019.11.11
-kpt pkg get https://github.com/forseti-security/policy-library.git ./policy-library
+kpt pkg get https://github.com/GoogleCloudPlatform/policy-library.git ./policy-library
 kpt fn source policy-library/samples/ | \
   kpt fn run --image gcr.io/config-validator/get-policy-bundle:latest -- bundle=$BUNDLE | \
   kpt fn sink policy-library/policies/constraints/

--- a/docs/bundles/healthcare-baseline-v1.md
+++ b/docs/bundles/healthcare-baseline-v1.md
@@ -4,7 +4,7 @@ This bundle can be installed via kpt:
 
 ```
 export BUNDLE=healthcare-baseline-v1
-kpt pkg get https://github.com/forseti-security/policy-library.git ./policy-library
+kpt pkg get https://github.com/GoogleCloudPlatform/policy-library.git ./policy-library
 kpt fn source policy-library/samples/ | \
   kpt fn run --image gcr.io/config-validator/get-policy-bundle:latest -- bundle=$BUNDLE | \
   kpt fn sink policy-library/policies/constraints/

--- a/docs/bundles/scorecard-v1.md
+++ b/docs/bundles/scorecard-v1.md
@@ -4,7 +4,7 @@ This bundle can be installed via kpt:
 
 ```
 export BUNDLE=scorecard-v1
-kpt pkg get https://github.com/forseti-security/policy-library.git ./policy-library
+kpt pkg get https://github.com/GoogleCloudPlatform/policy-library.git ./policy-library
 kpt fn source policy-library/samples/ | \
   kpt fn run --image gcr.io/config-validator/get-policy-bundle:latest -- bundle=$BUNDLE | \
   kpt fn sink policy-library/policies/constraints/

--- a/docs/kpt_functions.md
+++ b/docs/kpt_functions.md
@@ -4,7 +4,7 @@ This repo contains several [KPT](https://googlecontainertools.github.io/kpt-func
 These functions are meant to be run against this repo. Before running one of the below functions run `kpt get`:
 
 ```
-kpt pkg get https://github.com/forseti-security/policy-library.git ./policy-library
+kpt pkg get https://github.com/GoogleCloudPlatform/policy-library.git ./policy-library
 ```
 
 ## Get Policy Bundle

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -12,7 +12,7 @@
   * [Install Terraform Validator](#install-terraform-validator)
   * [For local development environments](#for-local-development-environments)
   * [For Production Environments](#for-production-environments)
-* [How to Use Forseti Config Validator](#how-to-use-forseti-config-validator)
+* [How to Use Config Validator with Forseti](#how-to-use-config-validator-with-Forseti)
   * [Deploy Forseti](#deploy-forseti)
   * [Policy Library Sync from Git Repository](https://forsetisecurity.org/docs/latest/configure/config-validator/policy-library-sync-from-git-repo.html)
   * [Policy Library Sync from GCS](https://forsetisecurity.org/docs/latest/configure/config-validator/policy-library-sync-from-gcs.html)
@@ -54,8 +54,8 @@ details, [check out Terraform Validator](#how-to-use-terraform-validator).
 
 Frequently scan the platform for constraint violations and send notifications
 when a violation is found. The monitoring logic that Config Validator uses will
-be built into a number of monitoring tools. For details,
-[check out Forseti Validator](#how-to-use-forseti-config-validator).
+be built into a number of monitoring tools. For example,
+[check out How to Use Config Validator with Forseti](#how-to-use-config-validator-with-forseti).
 
 The following guide will walk you through initial setup steps and instructions
 on how to use Config Validator. By the end, you will have a proof-of-concept to
@@ -81,9 +81,12 @@ Google provides a sample repository with a set of pre-defined constraint
 templates. You can duplicate this repository into a private repository. First
 you should create a new **private** git repository. For example, if you use
 GitHub then you can use the [GitHub UI](https://github.com/new). Then follow the
-steps below to get everything setup. If you are planning on using the [Policy
-Library Sync feature of Forseti](#policy-library-sync), then you should also add
-a read-only user to the private repository which will be used by Forseti.
+steps below to get everything setup. 
+
+_Note: If you are planning on using the
+[Policy Library Sync feature of Forseti](#policy-library-sync),
+then you should also add a read-only user to the private repository which will
+be used by Forseti._
 
 This policy library can also be made public, but it is not recommended. By
 making your policy library public, it would be allowing others to see what you
@@ -98,7 +101,7 @@ providers offer this feature as well.
 
 ```
 export GIT_REPO_ADDR="git@github.com:${YOUR_GITHUB_USERNAME}/policy-library.git"
-git clone --bare https://github.com/forseti-security/policy-library.git
+git clone --bare https://github.com/GoogleCloudPlatform/policy-library.git
 cd policy-library.git
 git push --mirror ${GIT_REPO_ADDR}
 cd ..
@@ -130,7 +133,7 @@ Periodically you should pull any changes from the public repository, which might
 contain new templates and Rego files.
 
 ```
-git remote add public https://github.com/forseti-security/policy-library.git
+git remote add public https://github.com/GoogleCloudPlatform/policy-library.git
 git pull public master
 git push origin master
 ```
@@ -342,7 +345,7 @@ return a `2` exit code if violations are found or `0` if no violations were
 found. Therefore, you should configure your CI to only proceed to the next step
 (for example, `terraform apply`) or merge if the validator exits successfully.
 
-## How to Use Forseti Config Validator
+## How to Use Config Validator with Forseti
 
 ### Deploy Forseti
 
@@ -373,7 +376,7 @@ In this section, you will apply a constraint that enforces IAM policy member
 domain restriction using [Cloud Shell](https://cloud.google.com/shell/).
 
 First click on this
-[link](https://console.cloud.google.com/cloudshell/open?cloudshell_image=gcr.io/graphite-cloud-shell-images/terraform:latest&cloudshell_git_repo=https://github.com/forseti-security/policy-library.git)
+[link](https://console.cloud.google.com/cloudshell/open?cloudshell_image=gcr.io/graphite-cloud-shell-images/terraform:latest&cloudshell_git_repo=https://github.com/GoogleCloudPlatform/policy-library.git)
 to open a new Cloud Shell session. The Cloud Shell session has Terraform
 pre-installed and the Policy Library repository cloned. Once you have the
 session open, the next step is to copy over the sample IAM domain restriction

--- a/policies/constraints/README.md
+++ b/policies/constraints/README.md
@@ -1,1 +1,1 @@
-This directory should contain the constraint .yaml files used in your environment. You can find sample constraints under https://github.com/forseti-security/policy-library/tree/master/samples.
+This directory should contain the constraint .yaml files used in your environment. You can find sample constraints under https://github.com/GoogleCloudPlatform/policy-library/tree/master/samples.


### PR DESCRIPTION
Config Validator (and this library) are no longer part of the forseti-security library, since they have broader applicability. This PR updates the repository locations, and also updates the docs to frame Config Validator as something that can be used with Forseti (rather than a component of it.)